### PR TITLE
Fix check for existing file

### DIFF
--- a/template/entrypoint.global.sh.twig
+++ b/template/entrypoint.global.sh.twig
@@ -103,7 +103,7 @@ echo "DOCKWARE: starting MySQL...."
 # sometimes they get lost :)
 # make sure that it is no longer present from the last run
 file = "/var/run/mysqld/mysqld.sock.lock"
-if [ -fe file ]
+if [ -f file ]
 then
     sudo rm -f  file
 fi


### PR DESCRIPTION
When running the script, I get an error `entrypoint.sh: line 38: [: -fe: unary operator expected`. To my understanding, this is because the bash test `-f` does exist but the test `-fe` does not. Perhaps a typo?