### PR TITLE
Fix error in variable assignment

### DIFF
--- a/template/entrypoint.global.sh.twig
+++ b/template/entrypoint.global.sh.twig
@@ -102,7 +102,7 @@ echo "DOCKWARE: starting MySQL...."
 # somehow its necessary to set permissions, because
 # sometimes they get lost :)
 # make sure that it is no longer present from the last run
-file = "/var/run/mysqld/mysqld.sock.lock"
+file="/var/run/mysqld/mysqld.sock.lock"
 if [ -fe file ]
 then
     sudo rm -f  file


### PR DESCRIPTION
At least in my bash environment, having whitespaces on both sides of the `=` equal sign, makes it a test operator. But in this case, it should actually be an assignment operator. This caused an error `test: =: unary operator expected` on my side.