### PR TITLE
add proper demo data

### DIFF
--- a/template/Dockerfile.global.sh.twig
+++ b/template/Dockerfile.global.sh.twig
@@ -436,7 +436,13 @@ RUN service mysql start && \
     # make sure assets like logos are ready
     cd /var/www/html && sudo -u www-data sh -c 'php bin/console assets:install' && \
     # add some demo data
+    {% if version_gte(shopware.version, '6.2.0-rc1') %}
+    cd /var/www/html && sudo -u www-data sh -c 'APP_ENV=prod php bin/console store:download -p SwagPlatformDemoData' && \
+    cd /var/www/html && sudo -u www-data sh -c 'APP_ENV=prod php bin/console plugin:refresh' && \
+    cd /var/www/html && sudo -u www-data sh -c 'APP_ENV=prod php bin/console plugin:install --activate SwagPlatformDemoData' && \
+    {% else %}
     cd /var/www/html && sudo -u www-data sh -c 'APP_ENV=prod php bin/console framework:demodata' && \
+    {% endif %}
     # clear cache and refresh dal index to show the new demo data
     cd /var/www/html && sudo -u www-data sh -c 'php bin/console cache:clear' && \
     cd /var/www/html && sudo -u www-data sh -c 'php bin/console dal:refresh:index' && \


### PR DESCRIPTION
This commit installs and activates Shopwares `SwagPlatformDemoData` plugin, which provides some proper demo data, instead of randomly generating cryptic articles, users, categories, etc.