### PR TITLE
add BUILD_PLUGIN option

### DIFF
--- a/template/entrypoint.global.sh.twig
+++ b/template/entrypoint.global.sh.twig
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 echo ""
 echo " _____   ____   _____ _  ____          __     _____  ______ "
 echo "|  __ \ / __ \ / ____| |/ /\ \        / /\   |  __ \|  ____|"
@@ -21,7 +22,7 @@ echo ""
 echo "launching dockware...please wait..."
 echo ""
 
-
+{% block entrypoint %}
 set -e
 
 source /etc/apache2/envvars
@@ -260,3 +261,4 @@ echo ""
 {% endblock %}
 
 tail -f /dev/null
+{% endblock%}

--- a/variants/dev/entrypoint.base.sh.twig
+++ b/variants/dev/entrypoint.base.sh.twig
@@ -1,2 +1,22 @@
 {% extends "template/entrypoint.global.sh.twig" %}
 
+{% block entrypoint %}
+{% if version_gte(shopware.version, '6.4') %}
+if [[ -z "${BUILD_PLUGIN}" ]]; then
+{{ parent() }}
+else
+{{ block('components_mysql') }}
+
+{% block install_plugin %}
+bin/console plugin:refresh && \
+bin/console plugin:install --activate "${BUILD_PLUGIN}"
+{% endblock %}
+
+{% block build_assets %}
+bin/build-js.sh
+{% endblock %}
+fi
+{% else %}
+{{ parent() }}
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
This commits enables you to run dockware binary-like to build a plugins assets.

**Example:** 
`docker run --rm -v $(PWD):/var/www/html/custom/plugins/MyPlugin -e BUILD_PLUGIN=MyPlugin dockware/dev:latest`
