### PR TITLE
Adding environment variable to define storefront api access key

### DIFF
--- a/template/Dockerfile.global.sh.twig
+++ b/template/Dockerfile.global.sh.twig
@@ -80,6 +80,11 @@ ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 {% endblock %}
 
+{% block image_variables_sw_api_access_key %}
+ENV SW_API_ACCESS_KEY 'not-set'
+RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
+{% endblock %}
+
 {% block image_variables_composer %}
 ENV COMPOSER_VERSION not-set
 RUN echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile

--- a/template/assets/assets/shopware6/files/set_api_access_key.php.twig
+++ b/template/assets/assets/shopware6/files/set_api_access_key.php.twig
@@ -1,0 +1,47 @@
+<?php
+
+require_once '/var/www/html/vendor/autoload.php';
+
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\FetchMode;
+
+
+$newAccessKey = $argv[1];
+
+/**
+ * So Shopware can work with the new sales channel api key, it needs the prefix swsc
+ * Check if the prefix was provided, otherwise set it
+ */
+$identifier = mb_substr($newAccessKey, 0, 4);
+if ($identifier != 'SWSC')
+{
+    $newAccessKey = 'SWSC' . $newAccessKey;
+}
+
+# ----------------------------------------------------------------------------
+$connString = "mysql://{{ db.user }}:{{ db.pwd }}@{{ db.host }}:{{ db.port }}/{{ db.database }}";
+
+$connection = DriverManager::getConnection([
+    'url' => $connString,
+    'charset' => 'utf8mb4',
+], new Configuration()
+);
+
+$connection->executeQuery('USE `{{ db.database }}`');
+# ----------------------------------------------------------------------------
+
+$sql = "
+START TRANSACTION;
+
+UPDATE sales_channel
+LEFT JOIN sales_channel_domain
+ON sales_channel.id = sales_channel_domain.sales_channel_id
+SET access_key = '" . $newAccessKey . "'
+WHERE sales_channel_domain.url = 'http://localhost';
+
+COMMIT;
+";
+
+$connection->executeQuery($sql);
+echo $newAccessKey;

--- a/template/entrypoint.global.sh.twig
+++ b/template/entrypoint.global.sh.twig
@@ -191,6 +191,19 @@ if [ $SW_CURRENCY != "not-set" ]; then
   echo "-----------------------------------------------------------"
 fi
 
+# The access key needs SWSC as a prefix, otherwise shopware
+# won't be able to access the storefront api.
+# The PHP script will automatically add it as a prefix, if
+# it was not defined in the environment variable.
+# The result "ACTUAL_API_ACCESS_KEY" contains the change.
+# It will be echoed at the end of the entrypoint, so the
+# user can see the actual api key they need to use.
+if [ $SW_API_ACCESS_KEY != "not-set" ]; then
+  echo "DOCKWARE: Set Shopware API access key..."
+  ACTUAL_API_ACCESS_KEY=$(php /var/www/scripts/shopware6/set_api_access_key.php $SW_API_ACCESS_KEY)
+  echo "-----------------------------------------------------------"
+fi
+
 {% endblock %}
 
 
@@ -248,6 +261,11 @@ echo "PIMPMYLOG URL: {{ shopware.url }}/logs"
 echo "SHOP URL: {{ shopware.url }}"
 {% block instructions_shopware_admin %}
 echo "ADMIN URL: {{ shopware.url }}/admin"
+{% endblock %}
+{% block instructions_shopware_api_access_key %}
+if [ $SW_API_ACCESS_KEY != "not-set" ]; then
+    echo "ACCESS KEY: ${ACTUAL_API_ACCESS_KEY}"
+fi
 {% endblock %}
 
 echo ""


### PR DESCRIPTION
The environment variable allows defining an API access key for the default storefront, listening to http://localhost.

`docker run --rm -e SW_API_ACCESS_KEY=MySecretAccessKey dockware/play:latest`

The result looks like this:

```
WOHOOO, dockware/play:latest IS READY :) - let's get started
-----------------------------------------------------
DOCKWARE CHANGELOG: /var/www/CHANGELOG.md
PHP: PHP 7.4.28 (cli) (built: Feb 17 2022 16:06:19) ( NTS )
Apache DocRoot: /var/www/html/public
ADMINER URL: http://localhost/adminer.php
MAILCATCHER URL: http://localhost/mailcatcher
PIMPMYLOG URL: http://localhost/logs
SHOP URL: http://localhost
ADMIN URL: http://localhost/admin
ACCESS KEY: SWSCMySecretAccessKey
```

Note that the storefront access key always needs the prefix SWSC, otherwise Shopware doesn't recognize the authentication. If the environment variable is missing, the prefix will be added, if it's present it will be taken as is.

Overall, this variable allows users to use Dockware in combination with external applications that need to access the API. You will be able to write a docker-compose that contains Dockware and your own application, both using the desired access key in their environments.

