### PR TITLE
Use entrypoint and CI detection to allow more flexible usage.

### DIFF
--- a/template/Dockerfile.global.sh.twig
+++ b/template/Dockerfile.global.sh.twig
@@ -512,4 +512,4 @@ WORKDIR /var/www/html
 # switch to non root user
 USER {{ ssh.user.name }}
 
-CMD ["/entrypoint.sh"]
+ENTRYPOINT ["/bin/bash" "/entrypoint.sh"]

--- a/template/entrypoint.global.sh.twig
+++ b/template/entrypoint.global.sh.twig
@@ -285,5 +285,9 @@ echo ""
 
 {% endblock %}
 
-tail -f /dev/null
+if [[ ! -z "$CI" ]]; then
+    exec "$@"
+else
+    tail -f /dev/null
+fi
 {% endblock%}


### PR DESCRIPTION
Some environments (like GitLab's CI runner) replace a CMD preventing the correct boot-up of dockware. By using the ENTRYPOINT directive, additional commands can be passed while still booting up correctly.
We detect CI environments with the widely used `$CI` environment variable to keep the current blocking behaviour intact and passing through commands only in CI environments.