### PR TITLE
Use custom CI variable to prevent failures in existing use cases.

### DIFF
--- a/template/entrypoint.global.sh.twig
+++ b/template/entrypoint.global.sh.twig
@@ -285,7 +285,7 @@ echo ""
 
 {% endblock %}
 
-if [[ ! -z "$CI" ]]; then
+if [[ ! -z "$DOCKWARE_CI" ]]; then
     exec "$@"
 else
     tail -f /dev/null


### PR DESCRIPTION
Current documentation suggests using `docker run` in CI pipelines, which would fail with just `$CI` as most CI platforms set this. A custom variable should allow for both existing and new use cases.