### PR TITLE
Provide Shopware 6.4.0.0 with dockware/play:6.4.0.0

### DIFF
--- a/variants/play/6.4.0.0/variables.json
+++ b/variants/play/6.4.0.0/variables.json
@@ -1,7 +1,7 @@
 {
     "shopware": {
-        "version": "6.4.1.0",
-        "download_url": "https://releases.shopware.com/sw6/install_v6.4.1.0_2951a105e0793ee8c3537b5987a938afdcb15002.zip"
+        "version": "6.4.0.0",
+        "download_url": "https://releases.shopware.com/sw6/install_v6.4.0.0_53c7ba74a3d915e6e8d045b59df1ae2922df15da.zip"
     },
     "php": {
         "versions": {


### PR DESCRIPTION
When I pull dockware/play:6.4.0.0 I get Shopware 6.4.1.0