### PR TITLE
Fix: Prevent double upgrade HTTP protocol version for SSL reverse proxies

### DIFF
--- a/template/assets/config/apache/sites.conf.twig
+++ b/template/assets/config/apache/sites.conf.twig
@@ -5,6 +5,8 @@
     ErrorLog /var/log/apache2/error.log
     AccessFileName .htaccess.watch .htaccess
 
+    Protocols http/1.1
+
     DocumentRoot __dockware_apache_docroot__
 
     <Directory /var/www/html>


### PR DESCRIPTION
**TLDR Version:**
When Dockware runs behind a HTTP/2 reverse proxy like [`nginxproxy/nginx-proxy` ](https://github.com/nginx-proxy/nginx-proxy), the current Apache config tries to upgrade the connection from incoming `h2` to `h2c`, which is a spec violation and leads to Safari (and also curl) blocking the server connection (other browsers seem not to be that strict).
Test: `curl -v https://shop.com`

**Solution:**
The solution is to limit the proto version for `:80` connections to `HTTP/1.1`, which is always preferable in Docker environments as they work internally without SSL and `HTTP/1.1` is the fastest option here. 
And for browser connections, there is no downside, because they only accept `HTTP/2` connections combined with SSL. So in case of running the shop without SSL, the connection will always be set to `HTTP/1.1` from browser side, because of the SSL requirement.

**Long version + error description:**
https://shopwarecommunity.slack.com/archives/C014X8HE8U8/p1681827486972799

**Issue analysis:**
https://megamorf.gitlab.io/2019/08/27/safari-nsposixerrordomain-100-error-with-nginx-and-apache/ 
However the provided solutions here are not preferable, as we want to force `HTTP/1.1` being used in the Docker environment. Otherwise, if we just remove the connection upgrade header, `HTTP/2` would be also used in the Docker network (which is possible without SSL while not communicating with a browser). But this can have negative impact on performance is some cases.

**Highly recommendable in depth guide about HTTP/2:**
https://www.nginx.com/blog/7-tips-for-faster-http2-performance/


**Sidenote:**
Switching our shop to `HTTP/2` (and `HTTP/1.1` inside Docker) gave us a performance boost of around 30% for cached pages, from 100-120ms to now 65-70ms.

If you want to have a test config including SSL for [`nginxproxy/nginx-proxy` ](https://github.com/nginx-proxy/nginx-proxy), feel free to use our template for automated serving and provisioning: https://github.com/umexco/main-nginx-proxy
