### PR TITLE
Adjust cron task for Shopware 6.5.0

### DIFF
--- a/template/assets/assets/scripts/cron/crontab.txt
+++ b/template/assets/assets/scripts/cron/crontab.txt
@@ -1,2 +1,11 @@
 */1 * * * * cd /var/www/html && php bin/console scheduled-task:run --time-limit=50 --memory-limit=125M
 */1 * * * * cd /var/www/html && php bin/console messenger:consume --time-limit=50
+
+# From Shopware 6.5.0, the cron task call must look like this (failed|async), otherwise it will not be running due to decision dialog:
+# Possibly requires to clear the cache to have the new schema
+# */1 * * * * cd /var/www/html && php bin/console messenger:consume failed --time-limit=50 --memory-limit=128M
+# */1 * * * * cd /var/www/html && php bin/console messenger:consume async --time-limit=50 --memory-limit=128M
+
+# Also recommendable to have n-1 messenger workers, depending on available CPU cores
+# */1 * * * * cd /var/www/html && php bin/console messenger:consume async --time-limit=50 --memory-limit=128M
+# */1 * * * * cd /var/www/html && php bin/console messenger:consume async --time-limit=50 --memory-limit=128M


### PR DESCRIPTION
From Shopware 6.5.0, the cron task call must look like this (failed|async), otherwise it will not be running due to decision dialog.

![image](https://github.com/dockware/dockware/assets/15804690/f532f1b8-de47-421e-8555-5e3550ba38c9)


Possibly requires to clear the cache to have the new schema