### PR TITLE
Fix custom mysql.user creation

### DIFF
--- a/template/entrypoint.global.sh.twig
+++ b/template/entrypoint.global.sh.twig
@@ -124,12 +124,12 @@ if [ $MYSQL_USER != "not-set" ] && [ $MYSQL_PWD != "not-set" ]; then
     sudo rm -rf /tmp/triggers.sql
     # -----------------------------------
     # block remote access for {{ db.user }} user
-    sudo mysql --user={{ db.user }} --password={{ db.pwd }} -e "UPDATE mysql.user SET Host='localhost' WHERE User='{{ db.user }}' AND Host='%';";
+    sudo mysql --user={{ db.user }} --password={{ db.pwd }} -e "DELETE FROM mysql.user WHERE User='{{ db.user }}' AND Host='%';";
     # -----------------------------------
     # add new user and grant privileges
     sudo mysql --user={{ db.user }} --password={{ db.pwd }} -e "CREATE USER IF NOT EXISTS '"$MYSQL_USER"'@'%' IDENTIFIED BY '"$MYSQL_PWD"';";
     sudo mysql --user={{ db.user }} --password={{ db.pwd }} -e "use mysql; update user set host='%' where user='$MYSQL_USER';";
-    sudo mysql --user={{ db.user }} --password={{ db.pwd }} -e "GRANT ALL PRIVILEGES ON *.* TO '"$MYSQL_USER"'@'%' IDENTIFIED BY '$MYSQL_PWD';";
+    sudo mysql --user={{ db.user }} --password={{ db.pwd }} -e "GRANT ALL PRIVILEGES ON *.* TO '"$MYSQL_USER"'@'%'";
     # -----------------------------------
     # apply and flush privileges
     sudo mysql --user={{ db.user }} --password={{ db.pwd }} -e "FLUSH PRIVILEGES;";


### PR DESCRIPTION
This PR fixes issue #181.

Due to recent changes (commit d8524b8), there exist two entries for root. 
One for host %  (root@'%')
One for host localhost. (root@localhost)

As a result, the prior UPDATE statement to change any host "%" to "localhost" fails, as it conflicts with the already existing entry root@localhost. To 'block remote access' for root - the intended behavior according to the comment - we simply now delete the second entry for any host root@'%'.

Unrelated, the "IDENTIFIED BY" had to be removed from the "GRANT ALL" because it is invalid syntax for the recently updated Mysql version.