### PR TITLE
Use APACHE_DOCROOT environment variable in <Directory> config

### DIFF
--- a/template/assets/config/apache/sites.conf.twig
+++ b/template/assets/config/apache/sites.conf.twig
@@ -7,7 +7,7 @@
 
     DocumentRoot __dockware_apache_docroot__
 
-    <Directory /var/www/html>
+    <Directory __dockware_apache_docroot__>
         Options -Indexes
         AllowOverride All
         Require all granted
@@ -68,7 +68,7 @@
         SetHandler "proxy:unix:/var/run/php/php__dockware_php_version__-fpm.sock|fcgi://localhost"
     </FilesMatch>
 
-    <Directory /var/www/html>
+    <Directory __dockware_apache_docroot__>
         Options -Indexes
         AllowOverride All
         Require all granted


### PR DESCRIPTION
When changing the apache docroot via the APACHE_DOCROOT environment variable you cannot access Shopware 6.
The ``<Directory>`` config in the apache site configuration is done for the /var/www/html folder and not for the new docroot.