### PR TITLE
Install php8.3 extensions and configure xdebug

### DIFF
--- a/template/components/php/8.3/install.sh.twig
+++ b/template/components/php/8.3/install.sh.twig
@@ -16,10 +16,10 @@
     && apt-get install -y php8.3-bcmath \
     && apt-get install -y php8.3-imap \
     && apt-get install -y php8.3-xdebug \
-    #&& apt-get install -y php8.3-redis \ NOT YET HERE
-    #&& apt-get install -y php8.3-amqp \ NOT YET HERE
-    #&& apt-get install -y php8.3-apcu \ NOT YET HERE
-    #&& apt-get install -y php8.3-pcov \ NOT YET HERE
+    && apt-get install -y php8.3-redis \
+    && apt-get install -y php8.3-amqp \
+    && apt-get install -y php8.3-apcu \
+    && apt-get install -y php8.3-pcov \
     && apt-get install -y dh-php \
     # shopware required pcre
     && apt-get install -y libpcre3 libpcre3-dev \

--- a/template/variables.json
+++ b/template/variables.json
@@ -20,8 +20,8 @@
             "8.3": {
                 "active": false,
                 "folder_id": "20230831",
-                "xdebug_version": "",
-                "xdebug_tag": "3.3.0alpha3"
+                "xdebug_version": "3",
+                "xdebug_tag": "3.3.2"
             },
             "8.2": {
                 "active": true,


### PR DESCRIPTION
This PR installs php 8.3 extensions, that were "disabled" because they were not available yet.

It also sets the correct xdebug version for 8.3. This also fixes https://github.com/dockware/dockware/issues/215