### PR TITLE
5x faster docker builds

### DIFF
--- a/.dist/versions/master/contribute/latest/Dockerfile
+++ b/.dist/versions/master/contribute/latest/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -441,11 +442,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -455,7 +454,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -473,7 +471,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -491,7 +488,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -509,7 +505,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -527,7 +522,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -545,7 +539,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -555,7 +548,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -623,12 +615,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -649,20 +638,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -678,7 +666,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -686,12 +673,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -742,15 +724,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -767,6 +745,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -779,6 +759,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/5.2.21/Dockerfile
+++ b/.dist/versions/master/dev/5.2.21/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,194 +197,189 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.1-fpm \
-    && apt-get install -y php7.1-apc \
-    && apt-get install -y php7.1-apcu \
-    && apt-get install -y php7.1-curl \
-    && apt-get install -y php7.1-cli \
-    && apt-get install -y php7.1-gd \
-    && apt-get install -y php7.1-json \
-    && apt-get install -y php7.1-ldap \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-pgsql \
-    && apt-get install -y php7.1-gettext \
-    && apt-get install -y php7.1-intl \
-    && apt-get install -y php7.1-xml \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-mbstring \
-    && apt-get install -y php7.1-zip \
-    && apt-get install -y php7.1-soap \
-    && apt-get install -y php7.1-memcached \
-    && apt-get install -y php7.1-redis \
-    && apt-get install -y php7.1-bcmath \
-    && apt-get install -y php7.1-imap \
-    && apt-get install -y php7.1-ssh2 \
-    && apt-get install -y php7.1-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.1-geoip \
-    && apt-get install -y php7.1-amqp \
-    && apt-get install -y php7.1-mongo \
+                            php7.1-apc \
+                            php7.1-apcu \
+                            php7.1-curl \
+                            php7.1-cli \
+                            php7.1-gd \
+                            php7.1-json \
+                            php7.1-ldap \
+                            php7.1-mysql \
+                            php7.1-pgsql \
+                            php7.1-gettext \
+                            php7.1-intl \
+                            php7.1-xml \
+                            php7.1-mysql \
+                            php7.1-mbstring \
+                            php7.1-zip \
+                            php7.1-soap \
+                            php7.1-memcached \
+                            php7.1-redis \
+                            php7.1-bcmath \
+                            php7.1-imap \
+                            php7.1-ssh2 \
+                            php7.1-pcov \
+                            dh-php \
+                            php7.1-geoip \
+                            php7.1-amqp \
+                            php7.1-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.1/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.0-fpm \
-    && apt-get install -y php7.0-apc \
-    && apt-get install -y php7.0-apcu \
-    && apt-get install -y php7.0-curl \
-    && apt-get install -y php7.0-cli \
-    && apt-get install -y php7.0-gd \
-    && apt-get install -y php7.0-json \
-    && apt-get install -y php7.0-ldap \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-pgsql \
-    && apt-get install -y php7.0-gettext \
-    && apt-get install -y php7.0-intl \
-    && apt-get install -y php7.0-xml \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-mbstring \
-    && apt-get install -y php7.0-zip \
-    && apt-get install -y php7.0-soap \
-    && apt-get install -y php7.0-memcached \
-    && apt-get install -y php7.0-redis \
-    && apt-get install -y php7.0-bcmath \
-    && apt-get install -y php7.0-imap \
-    && apt-get install -y php7.0-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.0-geoip \
-    && apt-get install -y php7.0-amqp \
-    && apt-get install -y php7.0-mongo \
+                            php7.0-apc \
+                            php7.0-apcu \
+                            php7.0-curl \
+                            php7.0-cli \
+                            php7.0-gd \
+                            php7.0-json \
+                            php7.0-ldap \
+                            php7.0-mysql \
+                            php7.0-pgsql \
+                            php7.0-gettext \
+                            php7.0-intl \
+                            php7.0-xml \
+                            php7.0-mysql \
+                            php7.0-mbstring \
+                            php7.0-zip \
+                            php7.0-soap \
+                            php7.0-memcached \
+                            php7.0-redis \
+                            php7.0-bcmath \
+                            php7.0-imap \
+                            php7.0-ssh2 \
+                            dh-php \
+                            php7.0-geoip \
+                            php7.0-amqp \
+                            php7.0-mongo \
 && cat /tmp/general.ini >| /etc/php/7.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.0/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php5.6-fpm \
-    && apt-get install -y php5.6-apc \
-    && apt-get install -y php5.6-apcu \
-    && apt-get install -y php5.6-curl \
-    && apt-get install -y php5.6-cli \
-    && apt-get install -y php5.6-gd \
-    && apt-get install -y php5.6-json \
-    && apt-get install -y php5.6-ldap \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-pgsql \
-    && apt-get install -y php5.6-gettext \
-    && apt-get install -y php5.6-intl \
-    && apt-get install -y php5.6-xml \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-mbstring \
-    && apt-get install -y php5.6-zip \
-    && apt-get install -y php5.6-soap \
-    && apt-get install -y php5.6-memcached \
-    && apt-get install -y php5.6-redis \
-    && apt-get install -y php5.6-bcmath \
-    && apt-get install -y php5.6-imap \
-    && apt-get install -y php5.6-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php5.6-geoip \
-    && apt-get install -y php5.6-amqp \
-    && apt-get install -y php5.6-mongo \
+                            php5.6-apc \
+                            php5.6-apcu \
+                            php5.6-curl \
+                            php5.6-cli \
+                            php5.6-gd \
+                            php5.6-json \
+                            php5.6-ldap \
+                            php5.6-mysql \
+                            php5.6-pgsql \
+                            php5.6-gettext \
+                            php5.6-intl \
+                            php5.6-xml \
+                            php5.6-mysql \
+                            php5.6-mbstring \
+                            php5.6-zip \
+                            php5.6-soap \
+                            php5.6-memcached \
+                            php5.6-redis \
+                            php5.6-bcmath \
+                            php5.6-imap \
+                            php5.6-ssh2 \
+                            dh-php \
+                            php5.6-geoip \
+                            php5.6-amqp \
+                            php5.6-mongo \
 && cat /tmp/general.ini >| /etc/php/5.6/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/5.6/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/5.6/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.0 > /dev/null 2>&1 &
@@ -411,20 +412,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -435,11 +434,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -449,7 +446,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -467,7 +463,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -485,7 +480,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -503,7 +497,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.1 \
     && sudo make \
@@ -521,7 +514,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.0 \
     && sudo make \
@@ -539,7 +531,6 @@ RUN cd /var/www \
     && rm -rf XDEBUG_2_5_5.zip \
     && mv xdebug-XDEBUG_2_5_5 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize5.6 \
     && sudo ./configure --with-php-config=/usr/bin/php-config5.6 \
     && sudo make \
@@ -549,7 +540,6 @@ RUN cd /var/www \
     && sudo phpize5.6 --clean \
     && sudo apt-get remove -y php5.6-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -617,12 +607,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -643,20 +630,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.2/mods-available/mailcatcher.ini && \
@@ -672,7 +658,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -680,12 +665,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -736,15 +716,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -760,6 +736,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/5.6/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/5.6/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.4.6/Dockerfile
+++ b/.dist/versions/master/dev/5.4.6/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,194 +197,189 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.1-fpm \
-    && apt-get install -y php7.1-apc \
-    && apt-get install -y php7.1-apcu \
-    && apt-get install -y php7.1-curl \
-    && apt-get install -y php7.1-cli \
-    && apt-get install -y php7.1-gd \
-    && apt-get install -y php7.1-json \
-    && apt-get install -y php7.1-ldap \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-pgsql \
-    && apt-get install -y php7.1-gettext \
-    && apt-get install -y php7.1-intl \
-    && apt-get install -y php7.1-xml \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-mbstring \
-    && apt-get install -y php7.1-zip \
-    && apt-get install -y php7.1-soap \
-    && apt-get install -y php7.1-memcached \
-    && apt-get install -y php7.1-redis \
-    && apt-get install -y php7.1-bcmath \
-    && apt-get install -y php7.1-imap \
-    && apt-get install -y php7.1-ssh2 \
-    && apt-get install -y php7.1-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.1-geoip \
-    && apt-get install -y php7.1-amqp \
-    && apt-get install -y php7.1-mongo \
+                            php7.1-apc \
+                            php7.1-apcu \
+                            php7.1-curl \
+                            php7.1-cli \
+                            php7.1-gd \
+                            php7.1-json \
+                            php7.1-ldap \
+                            php7.1-mysql \
+                            php7.1-pgsql \
+                            php7.1-gettext \
+                            php7.1-intl \
+                            php7.1-xml \
+                            php7.1-mysql \
+                            php7.1-mbstring \
+                            php7.1-zip \
+                            php7.1-soap \
+                            php7.1-memcached \
+                            php7.1-redis \
+                            php7.1-bcmath \
+                            php7.1-imap \
+                            php7.1-ssh2 \
+                            php7.1-pcov \
+                            dh-php \
+                            php7.1-geoip \
+                            php7.1-amqp \
+                            php7.1-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.1/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.0-fpm \
-    && apt-get install -y php7.0-apc \
-    && apt-get install -y php7.0-apcu \
-    && apt-get install -y php7.0-curl \
-    && apt-get install -y php7.0-cli \
-    && apt-get install -y php7.0-gd \
-    && apt-get install -y php7.0-json \
-    && apt-get install -y php7.0-ldap \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-pgsql \
-    && apt-get install -y php7.0-gettext \
-    && apt-get install -y php7.0-intl \
-    && apt-get install -y php7.0-xml \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-mbstring \
-    && apt-get install -y php7.0-zip \
-    && apt-get install -y php7.0-soap \
-    && apt-get install -y php7.0-memcached \
-    && apt-get install -y php7.0-redis \
-    && apt-get install -y php7.0-bcmath \
-    && apt-get install -y php7.0-imap \
-    && apt-get install -y php7.0-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.0-geoip \
-    && apt-get install -y php7.0-amqp \
-    && apt-get install -y php7.0-mongo \
+                            php7.0-apc \
+                            php7.0-apcu \
+                            php7.0-curl \
+                            php7.0-cli \
+                            php7.0-gd \
+                            php7.0-json \
+                            php7.0-ldap \
+                            php7.0-mysql \
+                            php7.0-pgsql \
+                            php7.0-gettext \
+                            php7.0-intl \
+                            php7.0-xml \
+                            php7.0-mysql \
+                            php7.0-mbstring \
+                            php7.0-zip \
+                            php7.0-soap \
+                            php7.0-memcached \
+                            php7.0-redis \
+                            php7.0-bcmath \
+                            php7.0-imap \
+                            php7.0-ssh2 \
+                            dh-php \
+                            php7.0-geoip \
+                            php7.0-amqp \
+                            php7.0-mongo \
 && cat /tmp/general.ini >| /etc/php/7.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.0/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php5.6-fpm \
-    && apt-get install -y php5.6-apc \
-    && apt-get install -y php5.6-apcu \
-    && apt-get install -y php5.6-curl \
-    && apt-get install -y php5.6-cli \
-    && apt-get install -y php5.6-gd \
-    && apt-get install -y php5.6-json \
-    && apt-get install -y php5.6-ldap \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-pgsql \
-    && apt-get install -y php5.6-gettext \
-    && apt-get install -y php5.6-intl \
-    && apt-get install -y php5.6-xml \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-mbstring \
-    && apt-get install -y php5.6-zip \
-    && apt-get install -y php5.6-soap \
-    && apt-get install -y php5.6-memcached \
-    && apt-get install -y php5.6-redis \
-    && apt-get install -y php5.6-bcmath \
-    && apt-get install -y php5.6-imap \
-    && apt-get install -y php5.6-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php5.6-geoip \
-    && apt-get install -y php5.6-amqp \
-    && apt-get install -y php5.6-mongo \
+                            php5.6-apc \
+                            php5.6-apcu \
+                            php5.6-curl \
+                            php5.6-cli \
+                            php5.6-gd \
+                            php5.6-json \
+                            php5.6-ldap \
+                            php5.6-mysql \
+                            php5.6-pgsql \
+                            php5.6-gettext \
+                            php5.6-intl \
+                            php5.6-xml \
+                            php5.6-mysql \
+                            php5.6-mbstring \
+                            php5.6-zip \
+                            php5.6-soap \
+                            php5.6-memcached \
+                            php5.6-redis \
+                            php5.6-bcmath \
+                            php5.6-imap \
+                            php5.6-ssh2 \
+                            dh-php \
+                            php5.6-geoip \
+                            php5.6-amqp \
+                            php5.6-mongo \
 && cat /tmp/general.ini >| /etc/php/5.6/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/5.6/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/5.6/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.0 > /dev/null 2>&1 &
@@ -411,20 +412,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -435,11 +434,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -449,7 +446,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -467,7 +463,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -485,7 +480,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -503,7 +497,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.1 \
     && sudo make \
@@ -521,7 +514,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.0 \
     && sudo make \
@@ -539,7 +531,6 @@ RUN cd /var/www \
     && rm -rf XDEBUG_2_5_5.zip \
     && mv xdebug-XDEBUG_2_5_5 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize5.6 \
     && sudo ./configure --with-php-config=/usr/bin/php-config5.6 \
     && sudo make \
@@ -549,7 +540,6 @@ RUN cd /var/www \
     && sudo phpize5.6 --clean \
     && sudo apt-get remove -y php5.6-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -617,12 +607,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -643,20 +630,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.2/mods-available/mailcatcher.ini && \
@@ -672,7 +658,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -680,12 +665,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -736,15 +716,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -760,6 +736,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/5.6/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/5.6/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.5.0/Dockerfile
+++ b/.dist/versions/master/dev/5.5.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,194 +197,189 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.1-fpm \
-    && apt-get install -y php7.1-apc \
-    && apt-get install -y php7.1-apcu \
-    && apt-get install -y php7.1-curl \
-    && apt-get install -y php7.1-cli \
-    && apt-get install -y php7.1-gd \
-    && apt-get install -y php7.1-json \
-    && apt-get install -y php7.1-ldap \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-pgsql \
-    && apt-get install -y php7.1-gettext \
-    && apt-get install -y php7.1-intl \
-    && apt-get install -y php7.1-xml \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-mbstring \
-    && apt-get install -y php7.1-zip \
-    && apt-get install -y php7.1-soap \
-    && apt-get install -y php7.1-memcached \
-    && apt-get install -y php7.1-redis \
-    && apt-get install -y php7.1-bcmath \
-    && apt-get install -y php7.1-imap \
-    && apt-get install -y php7.1-ssh2 \
-    && apt-get install -y php7.1-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.1-geoip \
-    && apt-get install -y php7.1-amqp \
-    && apt-get install -y php7.1-mongo \
+                            php7.1-apc \
+                            php7.1-apcu \
+                            php7.1-curl \
+                            php7.1-cli \
+                            php7.1-gd \
+                            php7.1-json \
+                            php7.1-ldap \
+                            php7.1-mysql \
+                            php7.1-pgsql \
+                            php7.1-gettext \
+                            php7.1-intl \
+                            php7.1-xml \
+                            php7.1-mysql \
+                            php7.1-mbstring \
+                            php7.1-zip \
+                            php7.1-soap \
+                            php7.1-memcached \
+                            php7.1-redis \
+                            php7.1-bcmath \
+                            php7.1-imap \
+                            php7.1-ssh2 \
+                            php7.1-pcov \
+                            dh-php \
+                            php7.1-geoip \
+                            php7.1-amqp \
+                            php7.1-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.1/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.0-fpm \
-    && apt-get install -y php7.0-apc \
-    && apt-get install -y php7.0-apcu \
-    && apt-get install -y php7.0-curl \
-    && apt-get install -y php7.0-cli \
-    && apt-get install -y php7.0-gd \
-    && apt-get install -y php7.0-json \
-    && apt-get install -y php7.0-ldap \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-pgsql \
-    && apt-get install -y php7.0-gettext \
-    && apt-get install -y php7.0-intl \
-    && apt-get install -y php7.0-xml \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-mbstring \
-    && apt-get install -y php7.0-zip \
-    && apt-get install -y php7.0-soap \
-    && apt-get install -y php7.0-memcached \
-    && apt-get install -y php7.0-redis \
-    && apt-get install -y php7.0-bcmath \
-    && apt-get install -y php7.0-imap \
-    && apt-get install -y php7.0-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.0-geoip \
-    && apt-get install -y php7.0-amqp \
-    && apt-get install -y php7.0-mongo \
+                            php7.0-apc \
+                            php7.0-apcu \
+                            php7.0-curl \
+                            php7.0-cli \
+                            php7.0-gd \
+                            php7.0-json \
+                            php7.0-ldap \
+                            php7.0-mysql \
+                            php7.0-pgsql \
+                            php7.0-gettext \
+                            php7.0-intl \
+                            php7.0-xml \
+                            php7.0-mysql \
+                            php7.0-mbstring \
+                            php7.0-zip \
+                            php7.0-soap \
+                            php7.0-memcached \
+                            php7.0-redis \
+                            php7.0-bcmath \
+                            php7.0-imap \
+                            php7.0-ssh2 \
+                            dh-php \
+                            php7.0-geoip \
+                            php7.0-amqp \
+                            php7.0-mongo \
 && cat /tmp/general.ini >| /etc/php/7.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.0/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php5.6-fpm \
-    && apt-get install -y php5.6-apc \
-    && apt-get install -y php5.6-apcu \
-    && apt-get install -y php5.6-curl \
-    && apt-get install -y php5.6-cli \
-    && apt-get install -y php5.6-gd \
-    && apt-get install -y php5.6-json \
-    && apt-get install -y php5.6-ldap \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-pgsql \
-    && apt-get install -y php5.6-gettext \
-    && apt-get install -y php5.6-intl \
-    && apt-get install -y php5.6-xml \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-mbstring \
-    && apt-get install -y php5.6-zip \
-    && apt-get install -y php5.6-soap \
-    && apt-get install -y php5.6-memcached \
-    && apt-get install -y php5.6-redis \
-    && apt-get install -y php5.6-bcmath \
-    && apt-get install -y php5.6-imap \
-    && apt-get install -y php5.6-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php5.6-geoip \
-    && apt-get install -y php5.6-amqp \
-    && apt-get install -y php5.6-mongo \
+                            php5.6-apc \
+                            php5.6-apcu \
+                            php5.6-curl \
+                            php5.6-cli \
+                            php5.6-gd \
+                            php5.6-json \
+                            php5.6-ldap \
+                            php5.6-mysql \
+                            php5.6-pgsql \
+                            php5.6-gettext \
+                            php5.6-intl \
+                            php5.6-xml \
+                            php5.6-mysql \
+                            php5.6-mbstring \
+                            php5.6-zip \
+                            php5.6-soap \
+                            php5.6-memcached \
+                            php5.6-redis \
+                            php5.6-bcmath \
+                            php5.6-imap \
+                            php5.6-ssh2 \
+                            dh-php \
+                            php5.6-geoip \
+                            php5.6-amqp \
+                            php5.6-mongo \
 && cat /tmp/general.ini >| /etc/php/5.6/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/5.6/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/5.6/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.0 > /dev/null 2>&1 &
@@ -411,20 +412,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -435,11 +434,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -449,7 +446,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -467,7 +463,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -485,7 +480,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -503,7 +497,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.1 \
     && sudo make \
@@ -521,7 +514,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.0 \
     && sudo make \
@@ -539,7 +531,6 @@ RUN cd /var/www \
     && rm -rf XDEBUG_2_5_5.zip \
     && mv xdebug-XDEBUG_2_5_5 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize5.6 \
     && sudo ./configure --with-php-config=/usr/bin/php-config5.6 \
     && sudo make \
@@ -549,7 +540,6 @@ RUN cd /var/www \
     && sudo phpize5.6 --clean \
     && sudo apt-get remove -y php5.6-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -617,12 +607,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -643,20 +630,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.2/mods-available/mailcatcher.ini && \
@@ -672,7 +658,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -680,12 +665,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -736,15 +716,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -760,6 +736,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/5.6/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/5.6/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.5.10/Dockerfile
+++ b/.dist/versions/master/dev/5.5.10/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,194 +197,189 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.1-fpm \
-    && apt-get install -y php7.1-apc \
-    && apt-get install -y php7.1-apcu \
-    && apt-get install -y php7.1-curl \
-    && apt-get install -y php7.1-cli \
-    && apt-get install -y php7.1-gd \
-    && apt-get install -y php7.1-json \
-    && apt-get install -y php7.1-ldap \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-pgsql \
-    && apt-get install -y php7.1-gettext \
-    && apt-get install -y php7.1-intl \
-    && apt-get install -y php7.1-xml \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-mbstring \
-    && apt-get install -y php7.1-zip \
-    && apt-get install -y php7.1-soap \
-    && apt-get install -y php7.1-memcached \
-    && apt-get install -y php7.1-redis \
-    && apt-get install -y php7.1-bcmath \
-    && apt-get install -y php7.1-imap \
-    && apt-get install -y php7.1-ssh2 \
-    && apt-get install -y php7.1-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.1-geoip \
-    && apt-get install -y php7.1-amqp \
-    && apt-get install -y php7.1-mongo \
+                            php7.1-apc \
+                            php7.1-apcu \
+                            php7.1-curl \
+                            php7.1-cli \
+                            php7.1-gd \
+                            php7.1-json \
+                            php7.1-ldap \
+                            php7.1-mysql \
+                            php7.1-pgsql \
+                            php7.1-gettext \
+                            php7.1-intl \
+                            php7.1-xml \
+                            php7.1-mysql \
+                            php7.1-mbstring \
+                            php7.1-zip \
+                            php7.1-soap \
+                            php7.1-memcached \
+                            php7.1-redis \
+                            php7.1-bcmath \
+                            php7.1-imap \
+                            php7.1-ssh2 \
+                            php7.1-pcov \
+                            dh-php \
+                            php7.1-geoip \
+                            php7.1-amqp \
+                            php7.1-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.1/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.0-fpm \
-    && apt-get install -y php7.0-apc \
-    && apt-get install -y php7.0-apcu \
-    && apt-get install -y php7.0-curl \
-    && apt-get install -y php7.0-cli \
-    && apt-get install -y php7.0-gd \
-    && apt-get install -y php7.0-json \
-    && apt-get install -y php7.0-ldap \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-pgsql \
-    && apt-get install -y php7.0-gettext \
-    && apt-get install -y php7.0-intl \
-    && apt-get install -y php7.0-xml \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-mbstring \
-    && apt-get install -y php7.0-zip \
-    && apt-get install -y php7.0-soap \
-    && apt-get install -y php7.0-memcached \
-    && apt-get install -y php7.0-redis \
-    && apt-get install -y php7.0-bcmath \
-    && apt-get install -y php7.0-imap \
-    && apt-get install -y php7.0-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.0-geoip \
-    && apt-get install -y php7.0-amqp \
-    && apt-get install -y php7.0-mongo \
+                            php7.0-apc \
+                            php7.0-apcu \
+                            php7.0-curl \
+                            php7.0-cli \
+                            php7.0-gd \
+                            php7.0-json \
+                            php7.0-ldap \
+                            php7.0-mysql \
+                            php7.0-pgsql \
+                            php7.0-gettext \
+                            php7.0-intl \
+                            php7.0-xml \
+                            php7.0-mysql \
+                            php7.0-mbstring \
+                            php7.0-zip \
+                            php7.0-soap \
+                            php7.0-memcached \
+                            php7.0-redis \
+                            php7.0-bcmath \
+                            php7.0-imap \
+                            php7.0-ssh2 \
+                            dh-php \
+                            php7.0-geoip \
+                            php7.0-amqp \
+                            php7.0-mongo \
 && cat /tmp/general.ini >| /etc/php/7.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.0/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php5.6-fpm \
-    && apt-get install -y php5.6-apc \
-    && apt-get install -y php5.6-apcu \
-    && apt-get install -y php5.6-curl \
-    && apt-get install -y php5.6-cli \
-    && apt-get install -y php5.6-gd \
-    && apt-get install -y php5.6-json \
-    && apt-get install -y php5.6-ldap \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-pgsql \
-    && apt-get install -y php5.6-gettext \
-    && apt-get install -y php5.6-intl \
-    && apt-get install -y php5.6-xml \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-mbstring \
-    && apt-get install -y php5.6-zip \
-    && apt-get install -y php5.6-soap \
-    && apt-get install -y php5.6-memcached \
-    && apt-get install -y php5.6-redis \
-    && apt-get install -y php5.6-bcmath \
-    && apt-get install -y php5.6-imap \
-    && apt-get install -y php5.6-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php5.6-geoip \
-    && apt-get install -y php5.6-amqp \
-    && apt-get install -y php5.6-mongo \
+                            php5.6-apc \
+                            php5.6-apcu \
+                            php5.6-curl \
+                            php5.6-cli \
+                            php5.6-gd \
+                            php5.6-json \
+                            php5.6-ldap \
+                            php5.6-mysql \
+                            php5.6-pgsql \
+                            php5.6-gettext \
+                            php5.6-intl \
+                            php5.6-xml \
+                            php5.6-mysql \
+                            php5.6-mbstring \
+                            php5.6-zip \
+                            php5.6-soap \
+                            php5.6-memcached \
+                            php5.6-redis \
+                            php5.6-bcmath \
+                            php5.6-imap \
+                            php5.6-ssh2 \
+                            dh-php \
+                            php5.6-geoip \
+                            php5.6-amqp \
+                            php5.6-mongo \
 && cat /tmp/general.ini >| /etc/php/5.6/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/5.6/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/5.6/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.0 > /dev/null 2>&1 &
@@ -411,20 +412,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -435,11 +434,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -449,7 +446,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -467,7 +463,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -485,7 +480,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -503,7 +497,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.1 \
     && sudo make \
@@ -521,7 +514,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.0 \
     && sudo make \
@@ -539,7 +531,6 @@ RUN cd /var/www \
     && rm -rf XDEBUG_2_5_5.zip \
     && mv xdebug-XDEBUG_2_5_5 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize5.6 \
     && sudo ./configure --with-php-config=/usr/bin/php-config5.6 \
     && sudo make \
@@ -549,7 +540,6 @@ RUN cd /var/www \
     && sudo phpize5.6 --clean \
     && sudo apt-get remove -y php5.6-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -617,12 +607,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -643,20 +630,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.2/mods-available/mailcatcher.ini && \
@@ -672,7 +658,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -680,12 +665,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -736,15 +716,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -760,6 +736,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/5.6/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/5.6/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.6.10/Dockerfile
+++ b/.dist/versions/master/dev/5.6.10/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,167 +197,164 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.2 > /dev/null 2>&1 &
@@ -384,20 +387,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -408,11 +409,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -422,7 +421,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -440,7 +438,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -458,7 +455,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -476,7 +472,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -494,7 +489,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -504,7 +498,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -564,12 +557,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -590,20 +580,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.4/mods-available/mailcatcher.ini && \
@@ -618,7 +607,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -626,12 +614,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -682,15 +665,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -704,6 +683,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.6.3/Dockerfile
+++ b/.dist/versions/master/dev/5.6.3/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,167 +197,164 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.2 > /dev/null 2>&1 &
@@ -384,20 +387,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -408,11 +409,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -422,7 +421,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -440,7 +438,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -458,7 +455,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -476,7 +472,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -494,7 +489,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -504,7 +498,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -564,12 +557,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -590,20 +580,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.4/mods-available/mailcatcher.ini && \
@@ -618,7 +607,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -626,12 +614,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -682,15 +665,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -704,6 +683,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.6.4/Dockerfile
+++ b/.dist/versions/master/dev/5.6.4/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,167 +197,164 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.0 > /dev/null 2>&1 &
@@ -384,20 +387,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -408,11 +409,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -422,7 +421,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -440,7 +438,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -458,7 +455,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -476,7 +472,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -494,7 +489,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -504,7 +498,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -564,12 +557,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -590,20 +580,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.4/mods-available/mailcatcher.ini && \
@@ -618,7 +607,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -626,12 +614,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -682,15 +665,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -704,6 +683,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.6.6/Dockerfile
+++ b/.dist/versions/master/dev/5.6.6/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,167 +197,164 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.0 > /dev/null 2>&1 &
@@ -384,20 +387,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -408,11 +409,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -422,7 +421,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -440,7 +438,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -458,7 +455,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -476,7 +472,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -494,7 +489,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -504,7 +498,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -564,12 +557,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -590,20 +580,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.4/mods-available/mailcatcher.ini && \
@@ -618,7 +607,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -626,12 +614,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -682,15 +665,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -704,6 +683,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.6.7/Dockerfile
+++ b/.dist/versions/master/dev/5.6.7/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,167 +197,164 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.2 > /dev/null 2>&1 &
@@ -384,20 +387,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -408,11 +409,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -422,7 +421,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -440,7 +438,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -458,7 +455,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -476,7 +472,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -494,7 +489,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -504,7 +498,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -564,12 +557,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -590,20 +580,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.4/mods-available/mailcatcher.ini && \
@@ -618,7 +607,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -626,12 +614,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -682,15 +665,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -704,6 +683,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.6.8/Dockerfile
+++ b/.dist/versions/master/dev/5.6.8/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,167 +197,164 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.2 > /dev/null 2>&1 &
@@ -384,20 +387,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -408,11 +409,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -422,7 +421,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -440,7 +438,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -458,7 +455,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -476,7 +472,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -494,7 +489,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -504,7 +498,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -564,12 +557,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -590,20 +580,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.4/mods-available/mailcatcher.ini && \
@@ -618,7 +607,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -626,12 +614,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -682,15 +665,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -704,6 +683,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.6.9/Dockerfile
+++ b/.dist/versions/master/dev/5.6.9/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,167 +197,164 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.2 > /dev/null 2>&1 &
@@ -384,20 +387,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -408,11 +409,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -422,7 +421,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -440,7 +438,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -458,7 +455,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -476,7 +472,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -494,7 +489,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -504,7 +498,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -564,12 +557,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -590,20 +580,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.4/mods-available/mailcatcher.ini && \
@@ -618,7 +607,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -626,12 +614,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -682,15 +665,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -704,6 +683,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.0-rc1/Dockerfile
+++ b/.dist/versions/master/dev/5.7.0-rc1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -440,11 +441,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -454,7 +453,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -472,7 +470,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -490,7 +487,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -508,7 +504,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -526,7 +521,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -544,7 +538,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -554,7 +547,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -622,12 +614,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -648,20 +637,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -677,7 +665,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -685,12 +672,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -741,15 +723,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -765,6 +743,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.0-rc2/Dockerfile
+++ b/.dist/versions/master/dev/5.7.0-rc2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -440,11 +441,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -454,7 +453,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -472,7 +470,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -490,7 +487,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -508,7 +504,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -526,7 +521,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -544,7 +538,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -554,7 +547,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -622,12 +614,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -648,20 +637,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -677,7 +665,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -685,12 +672,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -741,15 +723,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -765,6 +743,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.0/Dockerfile
+++ b/.dist/versions/master/dev/5.7.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -440,11 +441,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -454,7 +453,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -472,7 +470,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -490,7 +487,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -508,7 +504,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -526,7 +521,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -544,7 +538,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -554,7 +547,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -622,12 +614,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -648,20 +637,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -677,7 +665,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -685,12 +672,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -741,15 +723,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -765,6 +743,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.1/Dockerfile
+++ b/.dist/versions/master/dev/5.7.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.10/Dockerfile
+++ b/.dist/versions/master/dev/5.7.10/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.11/Dockerfile
+++ b/.dist/versions/master/dev/5.7.11/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.12/Dockerfile
+++ b/.dist/versions/master/dev/5.7.12/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.13/Dockerfile
+++ b/.dist/versions/master/dev/5.7.13/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.14/Dockerfile
+++ b/.dist/versions/master/dev/5.7.14/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.15/Dockerfile
+++ b/.dist/versions/master/dev/5.7.15/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.16-rc/Dockerfile
+++ b/.dist/versions/master/dev/5.7.16-rc/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.16/Dockerfile
+++ b/.dist/versions/master/dev/5.7.16/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.17/Dockerfile
+++ b/.dist/versions/master/dev/5.7.17/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.18/Dockerfile
+++ b/.dist/versions/master/dev/5.7.18/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -619,12 +611,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -646,20 +636,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +664,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +671,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +722,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +742,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.19/Dockerfile
+++ b/.dist/versions/master/dev/5.7.19/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,228 +197,225 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -445,20 +448,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -467,11 +468,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -481,7 +480,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -499,7 +497,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -517,7 +514,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -535,7 +531,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -553,7 +548,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -571,7 +565,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -589,7 +582,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -599,7 +591,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -674,12 +665,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -701,20 +690,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -731,7 +719,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -739,12 +726,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -795,15 +777,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -821,6 +799,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.2/Dockerfile
+++ b/.dist/versions/master/dev/5.7.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.3/Dockerfile
+++ b/.dist/versions/master/dev/5.7.3/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.4/Dockerfile
+++ b/.dist/versions/master/dev/5.7.4/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.5/Dockerfile
+++ b/.dist/versions/master/dev/5.7.5/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.6/Dockerfile
+++ b/.dist/versions/master/dev/5.7.6/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.7/Dockerfile
+++ b/.dist/versions/master/dev/5.7.7/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.8/Dockerfile
+++ b/.dist/versions/master/dev/5.7.8/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/5.7.9/Dockerfile
+++ b/.dist/versions/master/dev/5.7.9/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/6.1.0/Dockerfile
+++ b/.dist/versions/master/dev/6.1.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.1.1/Dockerfile
+++ b/.dist/versions/master/dev/6.1.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.1.3/Dockerfile
+++ b/.dist/versions/master/dev/6.1.3/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.1.4/Dockerfile
+++ b/.dist/versions/master/dev/6.1.4/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.1.5/Dockerfile
+++ b/.dist/versions/master/dev/6.1.5/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.1.6/Dockerfile
+++ b/.dist/versions/master/dev/6.1.6/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.2.0/Dockerfile
+++ b/.dist/versions/master/dev/6.2.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.2.1/Dockerfile
+++ b/.dist/versions/master/dev/6.2.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.2.2/Dockerfile
+++ b/.dist/versions/master/dev/6.2.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.2.3/Dockerfile
+++ b/.dist/versions/master/dev/6.2.3/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.3.0.0/Dockerfile
+++ b/.dist/versions/master/dev/6.3.0.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.3.0.1/Dockerfile
+++ b/.dist/versions/master/dev/6.3.0.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.3.0.2/Dockerfile
+++ b/.dist/versions/master/dev/6.3.0.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.3.1.0/Dockerfile
+++ b/.dist/versions/master/dev/6.3.1.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.3.1.1/Dockerfile
+++ b/.dist/versions/master/dev/6.3.1.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.3.2.0/Dockerfile
+++ b/.dist/versions/master/dev/6.3.2.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.3.2.1/Dockerfile
+++ b/.dist/versions/master/dev/6.3.2.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.3.3.0/Dockerfile
+++ b/.dist/versions/master/dev/6.3.3.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.3.3.1/Dockerfile
+++ b/.dist/versions/master/dev/6.3.3.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.3.4.0/Dockerfile
+++ b/.dist/versions/master/dev/6.3.4.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.3.4.1/Dockerfile
+++ b/.dist/versions/master/dev/6.3.4.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.3.5.0/Dockerfile
+++ b/.dist/versions/master/dev/6.3.5.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.3.5.1/Dockerfile
+++ b/.dist/versions/master/dev/6.3.5.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.3.5.2/Dockerfile
+++ b/.dist/versions/master/dev/6.3.5.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.3.5.3/Dockerfile
+++ b/.dist/versions/master/dev/6.3.5.3/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.3.5.4/Dockerfile
+++ b/.dist/versions/master/dev/6.3.5.4/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,199 +200,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -419,20 +422,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -443,11 +444,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -457,7 +456,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -475,7 +473,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -493,7 +490,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -511,7 +507,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -529,7 +524,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -547,7 +541,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -557,7 +550,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -625,12 +617,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -651,20 +640,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -680,7 +668,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -688,12 +675,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -744,15 +726,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -769,6 +747,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
 
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
 COPY ./assets/scripts/cron /var/www/scripts/cron
@@ -781,6 +761,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.0.0-rc1/Dockerfile
+++ b/.dist/versions/master/dev/6.4.0.0-rc1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.0.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.0.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.1.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.1.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.1.1/Dockerfile
+++ b/.dist/versions/master/dev/6.4.1.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.1.2/Dockerfile
+++ b/.dist/versions/master/dev/6.4.1.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.10.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.10.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.10.1/Dockerfile
+++ b/.dist/versions/master/dev/6.4.10.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.11.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.11.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.11.1/Dockerfile
+++ b/.dist/versions/master/dev/6.4.11.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.12.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.12.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.13.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.13.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.14.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.14.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.15.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.15.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.15.1/Dockerfile
+++ b/.dist/versions/master/dev/6.4.15.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.15.2/Dockerfile
+++ b/.dist/versions/master/dev/6.4.15.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.16.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.16.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.16.1/Dockerfile
+++ b/.dist/versions/master/dev/6.4.16.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.17.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.17.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.17.1/Dockerfile
+++ b/.dist/versions/master/dev/6.4.17.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.17.2/Dockerfile
+++ b/.dist/versions/master/dev/6.4.17.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.18.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.18.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.18.1/Dockerfile
+++ b/.dist/versions/master/dev/6.4.18.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.19.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.19.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.2.0-rc/Dockerfile
+++ b/.dist/versions/master/dev/6.4.2.0-rc/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.2.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.2.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.2.1/Dockerfile
+++ b/.dist/versions/master/dev/6.4.2.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.20.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.20.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.20.1/Dockerfile
+++ b/.dist/versions/master/dev/6.4.20.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.20.2/Dockerfile
+++ b/.dist/versions/master/dev/6.4.20.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.3.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.3.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.3.1/Dockerfile
+++ b/.dist/versions/master/dev/6.4.3.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.4.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.4.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.4.1/Dockerfile
+++ b/.dist/versions/master/dev/6.4.4.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.5.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.5.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.5.1/Dockerfile
+++ b/.dist/versions/master/dev/6.4.5.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.6.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.6.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.6.1/Dockerfile
+++ b/.dist/versions/master/dev/6.4.6.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.7.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.7.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.8.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.8.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.8.1/Dockerfile
+++ b/.dist/versions/master/dev/6.4.8.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.8.2/Dockerfile
+++ b/.dist/versions/master/dev/6.4.8.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.4.9.0/Dockerfile
+++ b/.dist/versions/master/dev/6.4.9.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,135 +200,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -355,20 +360,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -377,11 +380,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -391,7 +392,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -409,7 +409,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -427,7 +426,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -445,7 +443,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -455,7 +452,6 @@ RUN cd /var/www \
     && sudo phpize7.4 --clean \
     && sudo apt-get remove -y php7.4-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -507,12 +503,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -533,20 +526,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -560,7 +552,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -568,12 +559,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -624,15 +610,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -644,6 +626,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.4/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -657,6 +641,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/dev/6.5.0.0-rc1/Dockerfile
+++ b/.dist/versions/master/dev/6.5.0.0-rc1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,70 +200,69 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -290,20 +295,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -312,11 +315,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -326,7 +327,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -344,7 +344,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -354,7 +353,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -389,12 +387,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -416,20 +412,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
     echo ""
@@ -441,7 +436,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -449,12 +443,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -499,15 +488,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -515,6 +500,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/6.5.0.0-rc2/Dockerfile
+++ b/.dist/versions/master/dev/6.5.0.0-rc2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,70 +200,69 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -290,20 +295,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -312,11 +315,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -326,7 +327,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -344,7 +344,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -354,7 +353,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -389,12 +387,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -416,20 +412,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
     echo ""
@@ -441,7 +436,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -449,12 +443,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -499,15 +488,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -515,6 +500,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/6.5.0.0-rc3/Dockerfile
+++ b/.dist/versions/master/dev/6.5.0.0-rc3/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,70 +200,69 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -290,20 +295,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -312,11 +315,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -326,7 +327,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -344,7 +344,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -354,7 +353,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -389,12 +387,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -416,20 +412,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
     echo ""
@@ -441,7 +436,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -449,12 +443,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -499,15 +488,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -515,6 +500,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/6.5.0.0-rc4/Dockerfile
+++ b/.dist/versions/master/dev/6.5.0.0-rc4/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,70 +200,69 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -290,20 +295,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -312,11 +315,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -326,7 +327,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -344,7 +344,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -354,7 +353,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -389,12 +387,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -416,20 +412,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
     echo ""
@@ -441,7 +436,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -449,12 +443,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -499,15 +488,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -515,6 +500,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/dev/6.5.0.0/Dockerfile
+++ b/.dist/versions/master/dev/6.5.0.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.0.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.0.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.1.0/Dockerfile
+++ b/.dist/versions/master/dev/6.5.1.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.1.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.1.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.1.1/Dockerfile
+++ b/.dist/versions/master/dev/6.5.1.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.1.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.1.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.2.0/Dockerfile
+++ b/.dist/versions/master/dev/6.5.2.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.2.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.2.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.2.1/Dockerfile
+++ b/.dist/versions/master/dev/6.5.2.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.2.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.2.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.3.0/Dockerfile
+++ b/.dist/versions/master/dev/6.5.3.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.3.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.3.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.3.1/Dockerfile
+++ b/.dist/versions/master/dev/6.5.3.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.3.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.3.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.3.2/Dockerfile
+++ b/.dist/versions/master/dev/6.5.3.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.3.2
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.3.2" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.3.3/Dockerfile
+++ b/.dist/versions/master/dev/6.5.3.3/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.3.3
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.3.3" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.4.0/Dockerfile
+++ b/.dist/versions/master/dev/6.5.4.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.4.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.4.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.4.1/Dockerfile
+++ b/.dist/versions/master/dev/6.5.4.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.4.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.4.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.5.0/Dockerfile
+++ b/.dist/versions/master/dev/6.5.5.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.5.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.5.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.5.1/Dockerfile
+++ b/.dist/versions/master/dev/6.5.5.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.5.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.5.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.5.2/Dockerfile
+++ b/.dist/versions/master/dev/6.5.5.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.5.2
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.5.2" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.6.0/Dockerfile
+++ b/.dist/versions/master/dev/6.5.6.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.6.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.6.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.6.1/Dockerfile
+++ b/.dist/versions/master/dev/6.5.6.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.6.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.6.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.7.0/Dockerfile
+++ b/.dist/versions/master/dev/6.5.7.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.7.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.7.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.7.1/Dockerfile
+++ b/.dist/versions/master/dev/6.5.7.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.7.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.7.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.7.2/Dockerfile
+++ b/.dist/versions/master/dev/6.5.7.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.7.2
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.7.2" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.7.3/Dockerfile
+++ b/.dist/versions/master/dev/6.5.7.3/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.7.3
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.7.3" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.7.4/Dockerfile
+++ b/.dist/versions/master/dev/6.5.7.4/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.7.4
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.7.4" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.8.0/Dockerfile
+++ b/.dist/versions/master/dev/6.5.8.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.8.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.8.1/Dockerfile
+++ b/.dist/versions/master/dev/6.5.8.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.8.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.8.10/Dockerfile
+++ b/.dist/versions/master/dev/6.5.8.10/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -561,610 +549,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.10
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.8.10" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1174,6 +563,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1240,33 +631,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.8.11/Dockerfile
+++ b/.dist/versions/master/dev/6.5.8.11/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -561,610 +549,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.11
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.8.11" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1174,6 +563,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1240,33 +631,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.8.12/Dockerfile
+++ b/.dist/versions/master/dev/6.5.8.12/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -561,610 +549,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.12
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.8.12" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1174,6 +563,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1240,33 +631,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.8.2/Dockerfile
+++ b/.dist/versions/master/dev/6.5.8.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.2
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.8.2" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.8.3/Dockerfile
+++ b/.dist/versions/master/dev/6.5.8.3/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.3
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.8.3" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.8.4/Dockerfile
+++ b/.dist/versions/master/dev/6.5.8.4/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.4
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.8.4" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.8.5/Dockerfile
+++ b/.dist/versions/master/dev/6.5.8.5/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.5
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.8.5" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.8.6/Dockerfile
+++ b/.dist/versions/master/dev/6.5.8.6/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.6
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.8.6" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.8.7/Dockerfile
+++ b/.dist/versions/master/dev/6.5.8.7/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -555,604 +543,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.7
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.8.7" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1162,6 +557,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1228,33 +625,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.8.8/Dockerfile
+++ b/.dist/versions/master/dev/6.5.8.8/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -561,610 +549,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.8
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.8.8" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1174,6 +563,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1240,33 +631,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.5.8.9/Dockerfile
+++ b/.dist/versions/master/dev/6.5.8.9/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,99 +200,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -319,20 +324,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -341,11 +344,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -355,7 +356,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -373,7 +373,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -391,7 +390,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -401,7 +399,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -444,12 +441,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -471,20 +466,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -497,7 +491,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -505,12 +498,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -561,610 +549,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.9
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.5.8.9" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1174,6 +563,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1240,33 +631,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.6.0.0/Dockerfile
+++ b/.dist/versions/master/dev/6.6.0.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,67 +200,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -287,20 +292,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -309,11 +312,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -323,7 +324,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -341,7 +341,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -351,7 +350,6 @@ RUN cd /var/www \
     && sudo phpize8.2 --clean \
     && sudo apt-get remove -y php8.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -386,12 +384,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -413,20 +409,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -438,7 +433,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -446,12 +440,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -502,549 +491,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.0.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.6.0.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1052,6 +503,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1112,33 +565,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.6.0.1/Dockerfile
+++ b/.dist/versions/master/dev/6.6.0.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,67 +200,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -287,20 +292,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -309,11 +312,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -323,7 +324,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -341,7 +341,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -351,7 +350,6 @@ RUN cd /var/www \
     && sudo phpize8.2 --clean \
     && sudo apt-get remove -y php8.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -386,12 +384,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -413,20 +409,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -438,7 +433,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -446,12 +440,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -502,549 +491,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.0.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.6.0.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1052,6 +503,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1112,33 +565,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.6.0.2/Dockerfile
+++ b/.dist/versions/master/dev/6.6.0.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,67 +200,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -287,20 +292,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -309,11 +312,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -323,7 +324,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -341,7 +341,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -351,7 +350,6 @@ RUN cd /var/www \
     && sudo phpize8.2 --clean \
     && sudo apt-get remove -y php8.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -386,12 +384,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -413,20 +409,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -438,7 +433,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -446,12 +440,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -502,549 +491,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.0.2
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.6.0.2" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1052,6 +503,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1112,33 +565,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.6.1.0/Dockerfile
+++ b/.dist/versions/master/dev/6.6.1.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,67 +200,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -287,20 +292,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -309,11 +312,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -323,7 +324,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -341,7 +341,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -351,7 +350,6 @@ RUN cd /var/www \
     && sudo phpize8.2 --clean \
     && sudo apt-get remove -y php8.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -386,12 +384,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -413,20 +409,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -438,7 +433,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -446,12 +440,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -502,549 +491,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.1.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.6.1.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1052,6 +503,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1112,33 +565,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.6.1.1/Dockerfile
+++ b/.dist/versions/master/dev/6.6.1.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,67 +200,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -287,20 +292,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -309,11 +312,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -323,7 +324,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -341,7 +341,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -351,7 +350,6 @@ RUN cd /var/www \
     && sudo phpize8.2 --clean \
     && sudo apt-get remove -y php8.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -386,12 +384,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -413,20 +409,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -438,7 +433,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -446,12 +440,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -502,549 +491,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.1.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.6.1.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1052,6 +503,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1112,33 +565,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.6.1.2/Dockerfile
+++ b/.dist/versions/master/dev/6.6.1.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,67 +200,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -287,20 +292,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -309,11 +312,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -323,7 +324,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -341,7 +341,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -351,7 +350,6 @@ RUN cd /var/www \
     && sudo phpize8.2 --clean \
     && sudo apt-get remove -y php8.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -386,12 +384,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -413,20 +409,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -438,7 +433,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -446,12 +440,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -502,549 +491,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.1.2
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.6.1.2" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1052,6 +503,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1112,33 +565,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.6.2.0/Dockerfile
+++ b/.dist/versions/master/dev/6.6.2.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,67 +200,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -287,20 +292,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -309,11 +312,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -323,7 +324,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -341,7 +341,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -351,7 +350,6 @@ RUN cd /var/www \
     && sudo phpize8.2 --clean \
     && sudo apt-get remove -y php8.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -386,12 +384,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -413,20 +409,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -438,7 +433,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -446,12 +440,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -502,549 +491,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.2.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.6.2.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1052,6 +503,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1112,33 +565,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.6.3.0/Dockerfile
+++ b/.dist/versions/master/dev/6.6.3.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,67 +200,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -287,20 +292,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -309,11 +312,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -323,7 +324,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -341,7 +341,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -351,7 +350,6 @@ RUN cd /var/www \
     && sudo phpize8.2 --clean \
     && sudo apt-get remove -y php8.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -386,12 +384,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -413,20 +409,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -438,7 +433,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -446,12 +440,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -502,549 +491,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.3.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.6.3.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1052,6 +503,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1112,33 +565,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.6.3.1/Dockerfile
+++ b/.dist/versions/master/dev/6.6.3.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,67 +200,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -287,20 +292,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -309,11 +312,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -323,7 +324,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -341,7 +341,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -351,7 +350,6 @@ RUN cd /var/www \
     && sudo phpize8.2 --clean \
     && sudo apt-get remove -y php8.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -386,12 +384,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -413,20 +409,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -438,7 +433,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -446,12 +440,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -502,549 +491,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.3.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.6.3.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1052,6 +503,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1112,33 +565,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.6.4.0/Dockerfile
+++ b/.dist/versions/master/dev/6.6.4.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,67 +200,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -287,20 +292,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -309,11 +312,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -323,7 +324,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -341,7 +341,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -351,7 +350,6 @@ RUN cd /var/www \
     && sudo phpize8.2 --clean \
     && sudo apt-get remove -y php8.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -386,12 +384,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -413,20 +409,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -438,7 +433,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -446,12 +440,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -502,549 +491,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.4.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.6.4.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1052,6 +503,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1112,33 +565,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.6.4.1/Dockerfile
+++ b/.dist/versions/master/dev/6.6.4.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,67 +200,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -287,20 +292,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -309,11 +312,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -323,7 +324,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -341,7 +341,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -351,7 +350,6 @@ RUN cd /var/www \
     && sudo phpize8.2 --clean \
     && sudo apt-get remove -y php8.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -386,12 +384,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -413,20 +409,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -438,7 +433,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -446,12 +440,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -502,549 +491,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.4.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.6.4.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1052,6 +503,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1112,33 +565,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.6.5.0/Dockerfile
+++ b/.dist/versions/master/dev/6.6.5.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,67 +200,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -287,20 +292,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -309,11 +312,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -323,7 +324,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -341,7 +341,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -351,7 +350,6 @@ RUN cd /var/www \
     && sudo phpize8.2 --clean \
     && sudo apt-get remove -y php8.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -386,12 +384,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -413,20 +409,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -438,7 +433,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -446,12 +440,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -502,549 +491,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.5.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.6.5.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1052,6 +503,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1112,33 +565,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/6.6.5.1/Dockerfile
+++ b/.dist/versions/master/dev/6.6.5.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,67 +200,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -287,20 +292,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -309,11 +312,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -323,7 +324,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -341,7 +341,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -351,7 +350,6 @@ RUN cd /var/www \
     && sudo phpize8.2 --clean \
     && sudo apt-get remove -y php8.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -386,12 +384,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -413,20 +409,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -438,7 +433,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -446,12 +440,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -502,549 +491,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.5.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:6.6.5.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1052,6 +503,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1112,33 +565,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/dev/latest/Dockerfile
+++ b/.dist/versions/master/dev/latest/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,67 +200,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -287,20 +292,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -309,11 +312,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -323,7 +324,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -341,7 +341,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -351,7 +350,6 @@ RUN cd /var/www \
     && sudo phpize8.2 --clean \
     && sudo apt-get remove -y php8.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -386,12 +384,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -413,20 +409,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -438,7 +433,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -446,12 +440,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -502,549 +491,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: latest
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware dev:latest" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
-
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
     && echo ""
 
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
-
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
-
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1052,6 +503,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1112,33 +565,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \

--- a/.dist/versions/master/essentials/latest/Dockerfile
+++ b/.dist/versions/master/essentials/latest/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,320 +200,314 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.1-fpm \
-    && apt-get install -y php7.1-apc \
-    && apt-get install -y php7.1-apcu \
-    && apt-get install -y php7.1-curl \
-    && apt-get install -y php7.1-cli \
-    && apt-get install -y php7.1-gd \
-    && apt-get install -y php7.1-json \
-    && apt-get install -y php7.1-ldap \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-pgsql \
-    && apt-get install -y php7.1-gettext \
-    && apt-get install -y php7.1-intl \
-    && apt-get install -y php7.1-xml \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-mbstring \
-    && apt-get install -y php7.1-zip \
-    && apt-get install -y php7.1-soap \
-    && apt-get install -y php7.1-memcached \
-    && apt-get install -y php7.1-redis \
-    && apt-get install -y php7.1-bcmath \
-    && apt-get install -y php7.1-imap \
-    && apt-get install -y php7.1-ssh2 \
-    && apt-get install -y php7.1-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.1-geoip \
-    && apt-get install -y php7.1-amqp \
-    && apt-get install -y php7.1-mongo \
+                            php7.1-apc \
+                            php7.1-apcu \
+                            php7.1-curl \
+                            php7.1-cli \
+                            php7.1-gd \
+                            php7.1-json \
+                            php7.1-ldap \
+                            php7.1-mysql \
+                            php7.1-pgsql \
+                            php7.1-gettext \
+                            php7.1-intl \
+                            php7.1-xml \
+                            php7.1-mysql \
+                            php7.1-mbstring \
+                            php7.1-zip \
+                            php7.1-soap \
+                            php7.1-memcached \
+                            php7.1-redis \
+                            php7.1-bcmath \
+                            php7.1-imap \
+                            php7.1-ssh2 \
+                            php7.1-pcov \
+                            dh-php \
+                            php7.1-geoip \
+                            php7.1-amqp \
+                            php7.1-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.1/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.0-fpm \
-    && apt-get install -y php7.0-apc \
-    && apt-get install -y php7.0-apcu \
-    && apt-get install -y php7.0-curl \
-    && apt-get install -y php7.0-cli \
-    && apt-get install -y php7.0-gd \
-    && apt-get install -y php7.0-json \
-    && apt-get install -y php7.0-ldap \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-pgsql \
-    && apt-get install -y php7.0-gettext \
-    && apt-get install -y php7.0-intl \
-    && apt-get install -y php7.0-xml \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-mbstring \
-    && apt-get install -y php7.0-zip \
-    && apt-get install -y php7.0-soap \
-    && apt-get install -y php7.0-memcached \
-    && apt-get install -y php7.0-redis \
-    && apt-get install -y php7.0-bcmath \
-    && apt-get install -y php7.0-imap \
-    && apt-get install -y php7.0-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.0-geoip \
-    && apt-get install -y php7.0-amqp \
-    && apt-get install -y php7.0-mongo \
+                            php7.0-apc \
+                            php7.0-apcu \
+                            php7.0-curl \
+                            php7.0-cli \
+                            php7.0-gd \
+                            php7.0-json \
+                            php7.0-ldap \
+                            php7.0-mysql \
+                            php7.0-pgsql \
+                            php7.0-gettext \
+                            php7.0-intl \
+                            php7.0-xml \
+                            php7.0-mysql \
+                            php7.0-mbstring \
+                            php7.0-zip \
+                            php7.0-soap \
+                            php7.0-memcached \
+                            php7.0-redis \
+                            php7.0-bcmath \
+                            php7.0-imap \
+                            php7.0-ssh2 \
+                            dh-php \
+                            php7.0-geoip \
+                            php7.0-amqp \
+                            php7.0-mongo \
 && cat /tmp/general.ini >| /etc/php/7.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.0/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php5.6-fpm \
-    && apt-get install -y php5.6-apc \
-    && apt-get install -y php5.6-apcu \
-    && apt-get install -y php5.6-curl \
-    && apt-get install -y php5.6-cli \
-    && apt-get install -y php5.6-gd \
-    && apt-get install -y php5.6-json \
-    && apt-get install -y php5.6-ldap \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-pgsql \
-    && apt-get install -y php5.6-gettext \
-    && apt-get install -y php5.6-intl \
-    && apt-get install -y php5.6-xml \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-mbstring \
-    && apt-get install -y php5.6-zip \
-    && apt-get install -y php5.6-soap \
-    && apt-get install -y php5.6-memcached \
-    && apt-get install -y php5.6-redis \
-    && apt-get install -y php5.6-bcmath \
-    && apt-get install -y php5.6-imap \
-    && apt-get install -y php5.6-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php5.6-geoip \
-    && apt-get install -y php5.6-amqp \
-    && apt-get install -y php5.6-mongo \
+                            php5.6-apc \
+                            php5.6-apcu \
+                            php5.6-curl \
+                            php5.6-cli \
+                            php5.6-gd \
+                            php5.6-json \
+                            php5.6-ldap \
+                            php5.6-mysql \
+                            php5.6-pgsql \
+                            php5.6-gettext \
+                            php5.6-intl \
+                            php5.6-xml \
+                            php5.6-mysql \
+                            php5.6-mbstring \
+                            php5.6-zip \
+                            php5.6-soap \
+                            php5.6-memcached \
+                            php5.6-redis \
+                            php5.6-bcmath \
+                            php5.6-imap \
+                            php5.6-ssh2 \
+                            dh-php \
+                            php5.6-geoip \
+                            php5.6-amqp \
+                            php5.6-mongo \
 && cat /tmp/general.ini >| /etc/php/5.6/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/5.6/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/5.6/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.2 > /dev/null 2>&1 &
@@ -540,20 +540,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -562,11 +560,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -576,7 +572,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -594,7 +589,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -612,7 +606,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -630,7 +623,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -648,7 +640,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -666,7 +657,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -684,7 +674,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -702,7 +691,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.1 \
     && sudo make \
@@ -720,7 +708,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.0 \
     && sudo make \
@@ -738,7 +725,6 @@ RUN cd /var/www \
     && rm -rf XDEBUG_2_5_5.zip \
     && mv xdebug-XDEBUG_2_5_5 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize5.6 \
     && sudo ./configure --with-php-config=/usr/bin/php-config5.6 \
     && sudo make \
@@ -748,7 +734,6 @@ RUN cd /var/www \
     && sudo phpize5.6 --clean \
     && sudo apt-get remove -y php5.6-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -847,12 +832,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -874,20 +857,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -907,7 +889,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -915,12 +896,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -971,15 +947,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -1003,6 +975,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/5.6/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/5.6/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/essentials/test-php8.1/Dockerfile
+++ b/.dist/versions/master/essentials/test-php8.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -74,22 +75,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -99,12 +107,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -156,10 +164,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -174,8 +181,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -194,70 +200,69 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -290,20 +295,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -312,11 +315,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -326,7 +327,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -344,7 +344,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -354,7 +353,6 @@ RUN cd /var/www \
     && sudo phpize8.1 --clean \
     && sudo apt-get remove -y php8.1-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -390,12 +388,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -416,20 +411,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
     echo ""
@@ -441,7 +435,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -449,12 +442,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -505,15 +493,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -521,6 +505,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/flex/beta/Dockerfile
+++ b/.dist/versions/master/flex/beta/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -66,22 +67,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -90,12 +98,12 @@ RUN apt-get update \
     && dpkg-reconfigure --frontend noninteractive tzdata  \
      \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -147,10 +155,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -165,8 +172,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -185,291 +191,285 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.1-fpm \
-    && apt-get install -y php7.1-apc \
-    && apt-get install -y php7.1-apcu \
-    && apt-get install -y php7.1-curl \
-    && apt-get install -y php7.1-cli \
-    && apt-get install -y php7.1-gd \
-    && apt-get install -y php7.1-json \
-    && apt-get install -y php7.1-ldap \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-pgsql \
-    && apt-get install -y php7.1-gettext \
-    && apt-get install -y php7.1-intl \
-    && apt-get install -y php7.1-xml \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-mbstring \
-    && apt-get install -y php7.1-zip \
-    && apt-get install -y php7.1-soap \
-    && apt-get install -y php7.1-memcached \
-    && apt-get install -y php7.1-redis \
-    && apt-get install -y php7.1-bcmath \
-    && apt-get install -y php7.1-imap \
-    && apt-get install -y php7.1-ssh2 \
-    && apt-get install -y php7.1-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.1-geoip \
-    && apt-get install -y php7.1-amqp \
-    && apt-get install -y php7.1-mongo \
+                            php7.1-apc \
+                            php7.1-apcu \
+                            php7.1-curl \
+                            php7.1-cli \
+                            php7.1-gd \
+                            php7.1-json \
+                            php7.1-ldap \
+                            php7.1-mysql \
+                            php7.1-pgsql \
+                            php7.1-gettext \
+                            php7.1-intl \
+                            php7.1-xml \
+                            php7.1-mysql \
+                            php7.1-mbstring \
+                            php7.1-zip \
+                            php7.1-soap \
+                            php7.1-memcached \
+                            php7.1-redis \
+                            php7.1-bcmath \
+                            php7.1-imap \
+                            php7.1-ssh2 \
+                            php7.1-pcov \
+                            dh-php \
+                            php7.1-geoip \
+                            php7.1-amqp \
+                            php7.1-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.1/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.0-fpm \
-    && apt-get install -y php7.0-apc \
-    && apt-get install -y php7.0-apcu \
-    && apt-get install -y php7.0-curl \
-    && apt-get install -y php7.0-cli \
-    && apt-get install -y php7.0-gd \
-    && apt-get install -y php7.0-json \
-    && apt-get install -y php7.0-ldap \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-pgsql \
-    && apt-get install -y php7.0-gettext \
-    && apt-get install -y php7.0-intl \
-    && apt-get install -y php7.0-xml \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-mbstring \
-    && apt-get install -y php7.0-zip \
-    && apt-get install -y php7.0-soap \
-    && apt-get install -y php7.0-memcached \
-    && apt-get install -y php7.0-redis \
-    && apt-get install -y php7.0-bcmath \
-    && apt-get install -y php7.0-imap \
-    && apt-get install -y php7.0-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.0-geoip \
-    && apt-get install -y php7.0-amqp \
-    && apt-get install -y php7.0-mongo \
+                            php7.0-apc \
+                            php7.0-apcu \
+                            php7.0-curl \
+                            php7.0-cli \
+                            php7.0-gd \
+                            php7.0-json \
+                            php7.0-ldap \
+                            php7.0-mysql \
+                            php7.0-pgsql \
+                            php7.0-gettext \
+                            php7.0-intl \
+                            php7.0-xml \
+                            php7.0-mysql \
+                            php7.0-mbstring \
+                            php7.0-zip \
+                            php7.0-soap \
+                            php7.0-memcached \
+                            php7.0-redis \
+                            php7.0-bcmath \
+                            php7.0-imap \
+                            php7.0-ssh2 \
+                            dh-php \
+                            php7.0-geoip \
+                            php7.0-amqp \
+                            php7.0-mongo \
 && cat /tmp/general.ini >| /etc/php/7.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.0/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php5.6-fpm \
-    && apt-get install -y php5.6-apc \
-    && apt-get install -y php5.6-apcu \
-    && apt-get install -y php5.6-curl \
-    && apt-get install -y php5.6-cli \
-    && apt-get install -y php5.6-gd \
-    && apt-get install -y php5.6-json \
-    && apt-get install -y php5.6-ldap \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-pgsql \
-    && apt-get install -y php5.6-gettext \
-    && apt-get install -y php5.6-intl \
-    && apt-get install -y php5.6-xml \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-mbstring \
-    && apt-get install -y php5.6-zip \
-    && apt-get install -y php5.6-soap \
-    && apt-get install -y php5.6-memcached \
-    && apt-get install -y php5.6-redis \
-    && apt-get install -y php5.6-bcmath \
-    && apt-get install -y php5.6-imap \
-    && apt-get install -y php5.6-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php5.6-geoip \
-    && apt-get install -y php5.6-amqp \
-    && apt-get install -y php5.6-mongo \
+                            php5.6-apc \
+                            php5.6-apcu \
+                            php5.6-curl \
+                            php5.6-cli \
+                            php5.6-gd \
+                            php5.6-json \
+                            php5.6-ldap \
+                            php5.6-mysql \
+                            php5.6-pgsql \
+                            php5.6-gettext \
+                            php5.6-intl \
+                            php5.6-xml \
+                            php5.6-mysql \
+                            php5.6-mbstring \
+                            php5.6-zip \
+                            php5.6-soap \
+                            php5.6-memcached \
+                            php5.6-redis \
+                            php5.6-bcmath \
+                            php5.6-imap \
+                            php5.6-ssh2 \
+                            dh-php \
+                            php5.6-geoip \
+                            php5.6-amqp \
+                            php5.6-mongo \
 && cat /tmp/general.ini >| /etc/php/5.6/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/5.6/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/5.6/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -502,20 +502,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -524,11 +522,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -538,7 +534,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -556,7 +551,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -574,7 +568,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -592,7 +585,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -610,7 +602,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -628,7 +619,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -646,7 +636,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.1 \
     && sudo make \
@@ -664,7 +653,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.0 \
     && sudo make \
@@ -682,7 +670,6 @@ RUN cd /var/www \
     && rm -rf XDEBUG_2_5_5.zip \
     && mv xdebug-XDEBUG_2_5_5 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize5.6 \
     && sudo ./configure --with-php-config=/usr/bin/php-config5.6 \
     && sudo make \
@@ -692,7 +679,6 @@ RUN cd /var/www \
     && sudo phpize5.6 --clean \
     && sudo apt-get remove -y php5.6-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -772,12 +758,7 @@ RUN cd /var/www \
 
  && cd /var/www
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -832,15 +813,11 @@ RUN apt-get update && \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -862,6 +839,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/5.6/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/5.6/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/flex/latest/Dockerfile
+++ b/.dist/versions/master/flex/latest/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -66,22 +67,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -90,12 +98,12 @@ RUN apt-get update \
     && dpkg-reconfigure --frontend noninteractive tzdata  \
      \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -147,10 +155,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -165,8 +172,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -185,320 +191,314 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.1-fpm \
-    && apt-get install -y php7.1-apc \
-    && apt-get install -y php7.1-apcu \
-    && apt-get install -y php7.1-curl \
-    && apt-get install -y php7.1-cli \
-    && apt-get install -y php7.1-gd \
-    && apt-get install -y php7.1-json \
-    && apt-get install -y php7.1-ldap \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-pgsql \
-    && apt-get install -y php7.1-gettext \
-    && apt-get install -y php7.1-intl \
-    && apt-get install -y php7.1-xml \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-mbstring \
-    && apt-get install -y php7.1-zip \
-    && apt-get install -y php7.1-soap \
-    && apt-get install -y php7.1-memcached \
-    && apt-get install -y php7.1-redis \
-    && apt-get install -y php7.1-bcmath \
-    && apt-get install -y php7.1-imap \
-    && apt-get install -y php7.1-ssh2 \
-    && apt-get install -y php7.1-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.1-geoip \
-    && apt-get install -y php7.1-amqp \
-    && apt-get install -y php7.1-mongo \
+                            php7.1-apc \
+                            php7.1-apcu \
+                            php7.1-curl \
+                            php7.1-cli \
+                            php7.1-gd \
+                            php7.1-json \
+                            php7.1-ldap \
+                            php7.1-mysql \
+                            php7.1-pgsql \
+                            php7.1-gettext \
+                            php7.1-intl \
+                            php7.1-xml \
+                            php7.1-mysql \
+                            php7.1-mbstring \
+                            php7.1-zip \
+                            php7.1-soap \
+                            php7.1-memcached \
+                            php7.1-redis \
+                            php7.1-bcmath \
+                            php7.1-imap \
+                            php7.1-ssh2 \
+                            php7.1-pcov \
+                            dh-php \
+                            php7.1-geoip \
+                            php7.1-amqp \
+                            php7.1-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.1/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.0-fpm \
-    && apt-get install -y php7.0-apc \
-    && apt-get install -y php7.0-apcu \
-    && apt-get install -y php7.0-curl \
-    && apt-get install -y php7.0-cli \
-    && apt-get install -y php7.0-gd \
-    && apt-get install -y php7.0-json \
-    && apt-get install -y php7.0-ldap \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-pgsql \
-    && apt-get install -y php7.0-gettext \
-    && apt-get install -y php7.0-intl \
-    && apt-get install -y php7.0-xml \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-mbstring \
-    && apt-get install -y php7.0-zip \
-    && apt-get install -y php7.0-soap \
-    && apt-get install -y php7.0-memcached \
-    && apt-get install -y php7.0-redis \
-    && apt-get install -y php7.0-bcmath \
-    && apt-get install -y php7.0-imap \
-    && apt-get install -y php7.0-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.0-geoip \
-    && apt-get install -y php7.0-amqp \
-    && apt-get install -y php7.0-mongo \
+                            php7.0-apc \
+                            php7.0-apcu \
+                            php7.0-curl \
+                            php7.0-cli \
+                            php7.0-gd \
+                            php7.0-json \
+                            php7.0-ldap \
+                            php7.0-mysql \
+                            php7.0-pgsql \
+                            php7.0-gettext \
+                            php7.0-intl \
+                            php7.0-xml \
+                            php7.0-mysql \
+                            php7.0-mbstring \
+                            php7.0-zip \
+                            php7.0-soap \
+                            php7.0-memcached \
+                            php7.0-redis \
+                            php7.0-bcmath \
+                            php7.0-imap \
+                            php7.0-ssh2 \
+                            dh-php \
+                            php7.0-geoip \
+                            php7.0-amqp \
+                            php7.0-mongo \
 && cat /tmp/general.ini >| /etc/php/7.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.0/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php5.6-fpm \
-    && apt-get install -y php5.6-apc \
-    && apt-get install -y php5.6-apcu \
-    && apt-get install -y php5.6-curl \
-    && apt-get install -y php5.6-cli \
-    && apt-get install -y php5.6-gd \
-    && apt-get install -y php5.6-json \
-    && apt-get install -y php5.6-ldap \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-pgsql \
-    && apt-get install -y php5.6-gettext \
-    && apt-get install -y php5.6-intl \
-    && apt-get install -y php5.6-xml \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-mbstring \
-    && apt-get install -y php5.6-zip \
-    && apt-get install -y php5.6-soap \
-    && apt-get install -y php5.6-memcached \
-    && apt-get install -y php5.6-redis \
-    && apt-get install -y php5.6-bcmath \
-    && apt-get install -y php5.6-imap \
-    && apt-get install -y php5.6-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php5.6-geoip \
-    && apt-get install -y php5.6-amqp \
-    && apt-get install -y php5.6-mongo \
+                            php5.6-apc \
+                            php5.6-apcu \
+                            php5.6-curl \
+                            php5.6-cli \
+                            php5.6-gd \
+                            php5.6-json \
+                            php5.6-ldap \
+                            php5.6-mysql \
+                            php5.6-pgsql \
+                            php5.6-gettext \
+                            php5.6-intl \
+                            php5.6-xml \
+                            php5.6-mysql \
+                            php5.6-mbstring \
+                            php5.6-zip \
+                            php5.6-soap \
+                            php5.6-memcached \
+                            php5.6-redis \
+                            php5.6-bcmath \
+                            php5.6-imap \
+                            php5.6-ssh2 \
+                            dh-php \
+                            php5.6-geoip \
+                            php5.6-amqp \
+                            php5.6-mongo \
 && cat /tmp/general.ini >| /etc/php/5.6/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/5.6/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/5.6/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -531,20 +531,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -553,11 +551,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -567,7 +563,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -585,7 +580,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -603,7 +597,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -621,7 +614,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -639,7 +631,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -657,7 +648,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -675,7 +665,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -693,7 +682,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.1 \
     && sudo make \
@@ -711,7 +699,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.0 \
     && sudo make \
@@ -729,7 +716,6 @@ RUN cd /var/www \
     && rm -rf XDEBUG_2_5_5.zip \
     && mv xdebug-XDEBUG_2_5_5 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize5.6 \
     && sudo ./configure --with-php-config=/usr/bin/php-config5.6 \
     && sudo make \
@@ -739,7 +725,6 @@ RUN cd /var/www \
     && sudo phpize5.6 --clean \
     && sudo apt-get remove -y php5.6-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -827,12 +812,7 @@ RUN cd /var/www \
 
  && cd /var/www
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -883,15 +863,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -915,6 +891,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/5.6/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/5.6/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.2.21/Dockerfile
+++ b/.dist/versions/master/play/5.2.21/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,70 +197,67 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
-
+RUN echo "" \
     && apt-get install -y php7.0-fpm \
-    && apt-get install -y php7.0-apc \
-    && apt-get install -y php7.0-apcu \
-    && apt-get install -y php7.0-curl \
-    && apt-get install -y php7.0-cli \
-    && apt-get install -y php7.0-gd \
-    && apt-get install -y php7.0-json \
-    && apt-get install -y php7.0-ldap \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-pgsql \
-    && apt-get install -y php7.0-gettext \
-    && apt-get install -y php7.0-intl \
-    && apt-get install -y php7.0-xml \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-mbstring \
-    && apt-get install -y php7.0-zip \
-    && apt-get install -y php7.0-soap \
-    && apt-get install -y php7.0-memcached \
-    && apt-get install -y php7.0-redis \
-    && apt-get install -y php7.0-bcmath \
-    && apt-get install -y php7.0-imap \
-    && apt-get install -y php7.0-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.0-geoip \
-    && apt-get install -y php7.0-amqp \
-    && apt-get install -y php7.0-mongo \
+                            php7.0-apc \
+                            php7.0-apcu \
+                            php7.0-curl \
+                            php7.0-cli \
+                            php7.0-gd \
+                            php7.0-json \
+                            php7.0-ldap \
+                            php7.0-mysql \
+                            php7.0-pgsql \
+                            php7.0-gettext \
+                            php7.0-intl \
+                            php7.0-xml \
+                            php7.0-mysql \
+                            php7.0-mbstring \
+                            php7.0-zip \
+                            php7.0-soap \
+                            php7.0-memcached \
+                            php7.0-redis \
+                            php7.0-bcmath \
+                            php7.0-imap \
+                            php7.0-ssh2 \
+                            dh-php \
+                            php7.0-geoip \
+                            php7.0-amqp \
+                            php7.0-mongo \
 && cat /tmp/general.ini >| /etc/php/7.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.0/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php5.6-fpm \
-    && apt-get install -y php5.6-apc \
-    && apt-get install -y php5.6-apcu \
-    && apt-get install -y php5.6-curl \
-    && apt-get install -y php5.6-cli \
-    && apt-get install -y php5.6-gd \
-    && apt-get install -y php5.6-json \
-    && apt-get install -y php5.6-ldap \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-pgsql \
-    && apt-get install -y php5.6-gettext \
-    && apt-get install -y php5.6-intl \
-    && apt-get install -y php5.6-xml \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-mbstring \
-    && apt-get install -y php5.6-zip \
-    && apt-get install -y php5.6-soap \
-    && apt-get install -y php5.6-memcached \
-    && apt-get install -y php5.6-redis \
-    && apt-get install -y php5.6-bcmath \
-    && apt-get install -y php5.6-imap \
-    && apt-get install -y php5.6-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php5.6-geoip \
-    && apt-get install -y php5.6-amqp \
-    && apt-get install -y php5.6-mongo \
+                            php5.6-apc \
+                            php5.6-apcu \
+                            php5.6-curl \
+                            php5.6-cli \
+                            php5.6-gd \
+                            php5.6-json \
+                            php5.6-ldap \
+                            php5.6-mysql \
+                            php5.6-pgsql \
+                            php5.6-gettext \
+                            php5.6-intl \
+                            php5.6-xml \
+                            php5.6-mysql \
+                            php5.6-mbstring \
+                            php5.6-zip \
+                            php5.6-soap \
+                            php5.6-memcached \
+                            php5.6-redis \
+                            php5.6-bcmath \
+                            php5.6-imap \
+                            php5.6-ssh2 \
+                            dh-php \
+                            php5.6-geoip \
+                            php5.6-amqp \
+                            php5.6-mongo \
 && cat /tmp/general.ini >| /etc/php/5.6/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/5.6/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/5.6/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.0 > /dev/null 2>&1 &
@@ -287,20 +290,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -309,11 +310,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 7.0
     && sudo apt-get install -y php7.0-dev \
     && cd /var/www \
@@ -323,7 +322,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.0 \
     && sudo make \
@@ -341,7 +339,6 @@ RUN cd /var/www \
     && rm -rf XDEBUG_2_5_5.zip \
     && mv xdebug-XDEBUG_2_5_5 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize5.6 \
     && sudo ./configure --with-php-config=/usr/bin/php-config5.6 \
     && sudo make \
@@ -351,7 +348,6 @@ RUN cd /var/www \
     && sudo phpize5.6 --clean \
     && sudo apt-get remove -y php5.6-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -387,12 +383,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -413,20 +406,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.0/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/5.6/mods-available/mailcatcher.ini && \
     echo ""
@@ -438,7 +430,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -446,12 +437,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -502,15 +488,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/7.0/fpm/conf.d/20-tideways.ini \
@@ -518,6 +500,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/5.6/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/5.6/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.3.0/Dockerfile
+++ b/.dist/versions/master/play/5.3.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,70 +197,67 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
-
+RUN echo "" \
     && apt-get install -y php7.0-fpm \
-    && apt-get install -y php7.0-apc \
-    && apt-get install -y php7.0-apcu \
-    && apt-get install -y php7.0-curl \
-    && apt-get install -y php7.0-cli \
-    && apt-get install -y php7.0-gd \
-    && apt-get install -y php7.0-json \
-    && apt-get install -y php7.0-ldap \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-pgsql \
-    && apt-get install -y php7.0-gettext \
-    && apt-get install -y php7.0-intl \
-    && apt-get install -y php7.0-xml \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-mbstring \
-    && apt-get install -y php7.0-zip \
-    && apt-get install -y php7.0-soap \
-    && apt-get install -y php7.0-memcached \
-    && apt-get install -y php7.0-redis \
-    && apt-get install -y php7.0-bcmath \
-    && apt-get install -y php7.0-imap \
-    && apt-get install -y php7.0-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.0-geoip \
-    && apt-get install -y php7.0-amqp \
-    && apt-get install -y php7.0-mongo \
+                            php7.0-apc \
+                            php7.0-apcu \
+                            php7.0-curl \
+                            php7.0-cli \
+                            php7.0-gd \
+                            php7.0-json \
+                            php7.0-ldap \
+                            php7.0-mysql \
+                            php7.0-pgsql \
+                            php7.0-gettext \
+                            php7.0-intl \
+                            php7.0-xml \
+                            php7.0-mysql \
+                            php7.0-mbstring \
+                            php7.0-zip \
+                            php7.0-soap \
+                            php7.0-memcached \
+                            php7.0-redis \
+                            php7.0-bcmath \
+                            php7.0-imap \
+                            php7.0-ssh2 \
+                            dh-php \
+                            php7.0-geoip \
+                            php7.0-amqp \
+                            php7.0-mongo \
 && cat /tmp/general.ini >| /etc/php/7.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.0/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php5.6-fpm \
-    && apt-get install -y php5.6-apc \
-    && apt-get install -y php5.6-apcu \
-    && apt-get install -y php5.6-curl \
-    && apt-get install -y php5.6-cli \
-    && apt-get install -y php5.6-gd \
-    && apt-get install -y php5.6-json \
-    && apt-get install -y php5.6-ldap \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-pgsql \
-    && apt-get install -y php5.6-gettext \
-    && apt-get install -y php5.6-intl \
-    && apt-get install -y php5.6-xml \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-mbstring \
-    && apt-get install -y php5.6-zip \
-    && apt-get install -y php5.6-soap \
-    && apt-get install -y php5.6-memcached \
-    && apt-get install -y php5.6-redis \
-    && apt-get install -y php5.6-bcmath \
-    && apt-get install -y php5.6-imap \
-    && apt-get install -y php5.6-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php5.6-geoip \
-    && apt-get install -y php5.6-amqp \
-    && apt-get install -y php5.6-mongo \
+                            php5.6-apc \
+                            php5.6-apcu \
+                            php5.6-curl \
+                            php5.6-cli \
+                            php5.6-gd \
+                            php5.6-json \
+                            php5.6-ldap \
+                            php5.6-mysql \
+                            php5.6-pgsql \
+                            php5.6-gettext \
+                            php5.6-intl \
+                            php5.6-xml \
+                            php5.6-mysql \
+                            php5.6-mbstring \
+                            php5.6-zip \
+                            php5.6-soap \
+                            php5.6-memcached \
+                            php5.6-redis \
+                            php5.6-bcmath \
+                            php5.6-imap \
+                            php5.6-ssh2 \
+                            dh-php \
+                            php5.6-geoip \
+                            php5.6-amqp \
+                            php5.6-mongo \
 && cat /tmp/general.ini >| /etc/php/5.6/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/5.6/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/5.6/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.0 > /dev/null 2>&1 &
@@ -287,20 +290,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -309,11 +310,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 7.0
     && sudo apt-get install -y php7.0-dev \
     && cd /var/www \
@@ -323,7 +322,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.0 \
     && sudo make \
@@ -341,7 +339,6 @@ RUN cd /var/www \
     && rm -rf XDEBUG_2_5_5.zip \
     && mv xdebug-XDEBUG_2_5_5 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize5.6 \
     && sudo ./configure --with-php-config=/usr/bin/php-config5.6 \
     && sudo make \
@@ -351,7 +348,6 @@ RUN cd /var/www \
     && sudo phpize5.6 --clean \
     && sudo apt-get remove -y php5.6-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -387,12 +383,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -413,20 +406,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.0/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/5.6/mods-available/mailcatcher.ini && \
     echo ""
@@ -438,7 +430,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -446,12 +437,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -502,15 +488,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/7.0/fpm/conf.d/20-tideways.ini \
@@ -518,6 +500,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/5.6/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/5.6/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.4.6/Dockerfile
+++ b/.dist/versions/master/play/5.4.6/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,72 +197,69 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
-
+RUN echo "" \
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.0-fpm \
-    && apt-get install -y php7.0-apc \
-    && apt-get install -y php7.0-apcu \
-    && apt-get install -y php7.0-curl \
-    && apt-get install -y php7.0-cli \
-    && apt-get install -y php7.0-gd \
-    && apt-get install -y php7.0-json \
-    && apt-get install -y php7.0-ldap \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-pgsql \
-    && apt-get install -y php7.0-gettext \
-    && apt-get install -y php7.0-intl \
-    && apt-get install -y php7.0-xml \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-mbstring \
-    && apt-get install -y php7.0-zip \
-    && apt-get install -y php7.0-soap \
-    && apt-get install -y php7.0-memcached \
-    && apt-get install -y php7.0-redis \
-    && apt-get install -y php7.0-bcmath \
-    && apt-get install -y php7.0-imap \
-    && apt-get install -y php7.0-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.0-geoip \
-    && apt-get install -y php7.0-amqp \
-    && apt-get install -y php7.0-mongo \
+                            php7.0-apc \
+                            php7.0-apcu \
+                            php7.0-curl \
+                            php7.0-cli \
+                            php7.0-gd \
+                            php7.0-json \
+                            php7.0-ldap \
+                            php7.0-mysql \
+                            php7.0-pgsql \
+                            php7.0-gettext \
+                            php7.0-intl \
+                            php7.0-xml \
+                            php7.0-mysql \
+                            php7.0-mbstring \
+                            php7.0-zip \
+                            php7.0-soap \
+                            php7.0-memcached \
+                            php7.0-redis \
+                            php7.0-bcmath \
+                            php7.0-imap \
+                            php7.0-ssh2 \
+                            dh-php \
+                            php7.0-geoip \
+                            php7.0-amqp \
+                            php7.0-mongo \
 && cat /tmp/general.ini >| /etc/php/7.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.0/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.3 > /dev/null 2>&1 &
@@ -289,20 +292,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -311,11 +312,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 7.3
     && sudo apt-get install -y php7.3-dev \
     && cd /var/www \
@@ -325,7 +324,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -343,7 +341,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.0 \
     && sudo make \
@@ -353,7 +350,6 @@ RUN cd /var/www \
     && sudo phpize7.0 --clean \
     && sudo apt-get remove -y php7.0-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -389,12 +385,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -415,20 +408,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.0/mods-available/mailcatcher.ini && \
     echo ""
@@ -440,7 +432,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -448,12 +439,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -504,15 +490,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/7.3/fpm/conf.d/20-tideways.ini \
@@ -520,6 +502,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.0/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.0/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.5.0/Dockerfile
+++ b/.dist/versions/master/play/5.5.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,134 +197,129 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
-
+RUN echo "" \
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.1-fpm \
-    && apt-get install -y php7.1-apc \
-    && apt-get install -y php7.1-apcu \
-    && apt-get install -y php7.1-curl \
-    && apt-get install -y php7.1-cli \
-    && apt-get install -y php7.1-gd \
-    && apt-get install -y php7.1-json \
-    && apt-get install -y php7.1-ldap \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-pgsql \
-    && apt-get install -y php7.1-gettext \
-    && apt-get install -y php7.1-intl \
-    && apt-get install -y php7.1-xml \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-mbstring \
-    && apt-get install -y php7.1-zip \
-    && apt-get install -y php7.1-soap \
-    && apt-get install -y php7.1-memcached \
-    && apt-get install -y php7.1-redis \
-    && apt-get install -y php7.1-bcmath \
-    && apt-get install -y php7.1-imap \
-    && apt-get install -y php7.1-ssh2 \
-    && apt-get install -y php7.1-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.1-geoip \
-    && apt-get install -y php7.1-amqp \
-    && apt-get install -y php7.1-mongo \
+                            php7.1-apc \
+                            php7.1-apcu \
+                            php7.1-curl \
+                            php7.1-cli \
+                            php7.1-gd \
+                            php7.1-json \
+                            php7.1-ldap \
+                            php7.1-mysql \
+                            php7.1-pgsql \
+                            php7.1-gettext \
+                            php7.1-intl \
+                            php7.1-xml \
+                            php7.1-mysql \
+                            php7.1-mbstring \
+                            php7.1-zip \
+                            php7.1-soap \
+                            php7.1-memcached \
+                            php7.1-redis \
+                            php7.1-bcmath \
+                            php7.1-imap \
+                            php7.1-ssh2 \
+                            php7.1-pcov \
+                            dh-php \
+                            php7.1-geoip \
+                            php7.1-amqp \
+                            php7.1-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.1/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.0-fpm \
-    && apt-get install -y php7.0-apc \
-    && apt-get install -y php7.0-apcu \
-    && apt-get install -y php7.0-curl \
-    && apt-get install -y php7.0-cli \
-    && apt-get install -y php7.0-gd \
-    && apt-get install -y php7.0-json \
-    && apt-get install -y php7.0-ldap \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-pgsql \
-    && apt-get install -y php7.0-gettext \
-    && apt-get install -y php7.0-intl \
-    && apt-get install -y php7.0-xml \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-mbstring \
-    && apt-get install -y php7.0-zip \
-    && apt-get install -y php7.0-soap \
-    && apt-get install -y php7.0-memcached \
-    && apt-get install -y php7.0-redis \
-    && apt-get install -y php7.0-bcmath \
-    && apt-get install -y php7.0-imap \
-    && apt-get install -y php7.0-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.0-geoip \
-    && apt-get install -y php7.0-amqp \
-    && apt-get install -y php7.0-mongo \
+                            php7.0-apc \
+                            php7.0-apcu \
+                            php7.0-curl \
+                            php7.0-cli \
+                            php7.0-gd \
+                            php7.0-json \
+                            php7.0-ldap \
+                            php7.0-mysql \
+                            php7.0-pgsql \
+                            php7.0-gettext \
+                            php7.0-intl \
+                            php7.0-xml \
+                            php7.0-mysql \
+                            php7.0-mbstring \
+                            php7.0-zip \
+                            php7.0-soap \
+                            php7.0-memcached \
+                            php7.0-redis \
+                            php7.0-bcmath \
+                            php7.0-imap \
+                            php7.0-ssh2 \
+                            dh-php \
+                            php7.0-geoip \
+                            php7.0-amqp \
+                            php7.0-mongo \
 && cat /tmp/general.ini >| /etc/php/7.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.0/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php5.6-fpm \
-    && apt-get install -y php5.6-apc \
-    && apt-get install -y php5.6-apcu \
-    && apt-get install -y php5.6-curl \
-    && apt-get install -y php5.6-cli \
-    && apt-get install -y php5.6-gd \
-    && apt-get install -y php5.6-json \
-    && apt-get install -y php5.6-ldap \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-pgsql \
-    && apt-get install -y php5.6-gettext \
-    && apt-get install -y php5.6-intl \
-    && apt-get install -y php5.6-xml \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-mbstring \
-    && apt-get install -y php5.6-zip \
-    && apt-get install -y php5.6-soap \
-    && apt-get install -y php5.6-memcached \
-    && apt-get install -y php5.6-redis \
-    && apt-get install -y php5.6-bcmath \
-    && apt-get install -y php5.6-imap \
-    && apt-get install -y php5.6-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php5.6-geoip \
-    && apt-get install -y php5.6-amqp \
-    && apt-get install -y php5.6-mongo \
+                            php5.6-apc \
+                            php5.6-apcu \
+                            php5.6-curl \
+                            php5.6-cli \
+                            php5.6-gd \
+                            php5.6-json \
+                            php5.6-ldap \
+                            php5.6-mysql \
+                            php5.6-pgsql \
+                            php5.6-gettext \
+                            php5.6-intl \
+                            php5.6-xml \
+                            php5.6-mysql \
+                            php5.6-mbstring \
+                            php5.6-zip \
+                            php5.6-soap \
+                            php5.6-memcached \
+                            php5.6-redis \
+                            php5.6-bcmath \
+                            php5.6-imap \
+                            php5.6-ssh2 \
+                            dh-php \
+                            php5.6-geoip \
+                            php5.6-amqp \
+                            php5.6-mongo \
 && cat /tmp/general.ini >| /etc/php/5.6/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/5.6/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/5.6/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.0 > /dev/null 2>&1 &
@@ -351,20 +352,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -373,11 +372,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 7.2
     && sudo apt-get install -y php7.2-dev \
     && cd /var/www \
@@ -387,7 +384,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -405,7 +401,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.1 \
     && sudo make \
@@ -423,7 +418,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.0 \
     && sudo make \
@@ -441,7 +435,6 @@ RUN cd /var/www \
     && rm -rf XDEBUG_2_5_5.zip \
     && mv xdebug-XDEBUG_2_5_5 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize5.6 \
     && sudo ./configure --with-php-config=/usr/bin/php-config5.6 \
     && sudo make \
@@ -451,7 +444,6 @@ RUN cd /var/www \
     && sudo phpize5.6 --clean \
     && sudo apt-get remove -y php5.6-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -503,12 +495,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -529,20 +518,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.0/mods-available/mailcatcher.ini && \
@@ -556,7 +544,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -564,12 +551,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -620,15 +602,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
@@ -640,6 +618,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/5.6/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/5.6/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.5.10/Dockerfile
+++ b/.dist/versions/master/play/5.5.10/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,134 +197,129 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
-
+RUN echo "" \
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.1-fpm \
-    && apt-get install -y php7.1-apc \
-    && apt-get install -y php7.1-apcu \
-    && apt-get install -y php7.1-curl \
-    && apt-get install -y php7.1-cli \
-    && apt-get install -y php7.1-gd \
-    && apt-get install -y php7.1-json \
-    && apt-get install -y php7.1-ldap \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-pgsql \
-    && apt-get install -y php7.1-gettext \
-    && apt-get install -y php7.1-intl \
-    && apt-get install -y php7.1-xml \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-mbstring \
-    && apt-get install -y php7.1-zip \
-    && apt-get install -y php7.1-soap \
-    && apt-get install -y php7.1-memcached \
-    && apt-get install -y php7.1-redis \
-    && apt-get install -y php7.1-bcmath \
-    && apt-get install -y php7.1-imap \
-    && apt-get install -y php7.1-ssh2 \
-    && apt-get install -y php7.1-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.1-geoip \
-    && apt-get install -y php7.1-amqp \
-    && apt-get install -y php7.1-mongo \
+                            php7.1-apc \
+                            php7.1-apcu \
+                            php7.1-curl \
+                            php7.1-cli \
+                            php7.1-gd \
+                            php7.1-json \
+                            php7.1-ldap \
+                            php7.1-mysql \
+                            php7.1-pgsql \
+                            php7.1-gettext \
+                            php7.1-intl \
+                            php7.1-xml \
+                            php7.1-mysql \
+                            php7.1-mbstring \
+                            php7.1-zip \
+                            php7.1-soap \
+                            php7.1-memcached \
+                            php7.1-redis \
+                            php7.1-bcmath \
+                            php7.1-imap \
+                            php7.1-ssh2 \
+                            php7.1-pcov \
+                            dh-php \
+                            php7.1-geoip \
+                            php7.1-amqp \
+                            php7.1-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.1/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.0-fpm \
-    && apt-get install -y php7.0-apc \
-    && apt-get install -y php7.0-apcu \
-    && apt-get install -y php7.0-curl \
-    && apt-get install -y php7.0-cli \
-    && apt-get install -y php7.0-gd \
-    && apt-get install -y php7.0-json \
-    && apt-get install -y php7.0-ldap \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-pgsql \
-    && apt-get install -y php7.0-gettext \
-    && apt-get install -y php7.0-intl \
-    && apt-get install -y php7.0-xml \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-mbstring \
-    && apt-get install -y php7.0-zip \
-    && apt-get install -y php7.0-soap \
-    && apt-get install -y php7.0-memcached \
-    && apt-get install -y php7.0-redis \
-    && apt-get install -y php7.0-bcmath \
-    && apt-get install -y php7.0-imap \
-    && apt-get install -y php7.0-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.0-geoip \
-    && apt-get install -y php7.0-amqp \
-    && apt-get install -y php7.0-mongo \
+                            php7.0-apc \
+                            php7.0-apcu \
+                            php7.0-curl \
+                            php7.0-cli \
+                            php7.0-gd \
+                            php7.0-json \
+                            php7.0-ldap \
+                            php7.0-mysql \
+                            php7.0-pgsql \
+                            php7.0-gettext \
+                            php7.0-intl \
+                            php7.0-xml \
+                            php7.0-mysql \
+                            php7.0-mbstring \
+                            php7.0-zip \
+                            php7.0-soap \
+                            php7.0-memcached \
+                            php7.0-redis \
+                            php7.0-bcmath \
+                            php7.0-imap \
+                            php7.0-ssh2 \
+                            dh-php \
+                            php7.0-geoip \
+                            php7.0-amqp \
+                            php7.0-mongo \
 && cat /tmp/general.ini >| /etc/php/7.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.0/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php5.6-fpm \
-    && apt-get install -y php5.6-apc \
-    && apt-get install -y php5.6-apcu \
-    && apt-get install -y php5.6-curl \
-    && apt-get install -y php5.6-cli \
-    && apt-get install -y php5.6-gd \
-    && apt-get install -y php5.6-json \
-    && apt-get install -y php5.6-ldap \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-pgsql \
-    && apt-get install -y php5.6-gettext \
-    && apt-get install -y php5.6-intl \
-    && apt-get install -y php5.6-xml \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-mbstring \
-    && apt-get install -y php5.6-zip \
-    && apt-get install -y php5.6-soap \
-    && apt-get install -y php5.6-memcached \
-    && apt-get install -y php5.6-redis \
-    && apt-get install -y php5.6-bcmath \
-    && apt-get install -y php5.6-imap \
-    && apt-get install -y php5.6-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php5.6-geoip \
-    && apt-get install -y php5.6-amqp \
-    && apt-get install -y php5.6-mongo \
+                            php5.6-apc \
+                            php5.6-apcu \
+                            php5.6-curl \
+                            php5.6-cli \
+                            php5.6-gd \
+                            php5.6-json \
+                            php5.6-ldap \
+                            php5.6-mysql \
+                            php5.6-pgsql \
+                            php5.6-gettext \
+                            php5.6-intl \
+                            php5.6-xml \
+                            php5.6-mysql \
+                            php5.6-mbstring \
+                            php5.6-zip \
+                            php5.6-soap \
+                            php5.6-memcached \
+                            php5.6-redis \
+                            php5.6-bcmath \
+                            php5.6-imap \
+                            php5.6-ssh2 \
+                            dh-php \
+                            php5.6-geoip \
+                            php5.6-amqp \
+                            php5.6-mongo \
 && cat /tmp/general.ini >| /etc/php/5.6/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/5.6/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/5.6/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.0 > /dev/null 2>&1 &
@@ -351,20 +352,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -373,11 +372,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 7.2
     && sudo apt-get install -y php7.2-dev \
     && cd /var/www \
@@ -387,7 +384,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -405,7 +401,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.1 \
     && sudo make \
@@ -423,7 +418,6 @@ RUN cd /var/www \
     && rm -rf 2.7.2.zip \
     && mv xdebug-2.7.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.0 \
     && sudo make \
@@ -441,7 +435,6 @@ RUN cd /var/www \
     && rm -rf XDEBUG_2_5_5.zip \
     && mv xdebug-XDEBUG_2_5_5 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize5.6 \
     && sudo ./configure --with-php-config=/usr/bin/php-config5.6 \
     && sudo make \
@@ -451,7 +444,6 @@ RUN cd /var/www \
     && sudo phpize5.6 --clean \
     && sudo apt-get remove -y php5.6-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -503,12 +495,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -529,20 +518,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.0/mods-available/mailcatcher.ini && \
@@ -556,7 +544,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -564,12 +551,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -620,15 +602,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
@@ -640,6 +618,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/5.6/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/5.6/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.6.10/Dockerfile
+++ b/.dist/versions/master/play/5.6.10/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,107 +197,104 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.2 > /dev/null 2>&1 &
@@ -324,20 +327,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -346,11 +347,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 7.4
     && sudo apt-get install -y php7.4-dev \
     && cd /var/www \
@@ -360,7 +359,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -378,7 +376,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -396,7 +393,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -406,7 +402,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -450,12 +445,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -476,20 +468,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.4/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.2/mods-available/mailcatcher.ini && \
@@ -502,7 +493,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -510,12 +500,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -566,15 +551,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
@@ -584,6 +565,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.6.3/Dockerfile
+++ b/.dist/versions/master/play/5.6.3/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,107 +197,104 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.2 > /dev/null 2>&1 &
@@ -324,20 +327,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -346,11 +347,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 7.4
     && sudo apt-get install -y php7.4-dev \
     && cd /var/www \
@@ -360,7 +359,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -378,7 +376,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -396,7 +393,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -406,7 +402,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -450,12 +445,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -476,20 +468,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.4/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.2/mods-available/mailcatcher.ini && \
@@ -502,7 +493,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -510,12 +500,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -566,15 +551,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
@@ -584,6 +565,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.6.4/Dockerfile
+++ b/.dist/versions/master/play/5.6.4/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,107 +197,104 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.0 > /dev/null 2>&1 &
@@ -324,20 +327,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -346,11 +347,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 7.4
     && sudo apt-get install -y php7.4-dev \
     && cd /var/www \
@@ -360,7 +359,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -378,7 +376,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -396,7 +393,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -406,7 +402,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -450,12 +445,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -476,20 +468,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.4/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.2/mods-available/mailcatcher.ini && \
@@ -502,7 +493,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -510,12 +500,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -566,15 +551,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
@@ -584,6 +565,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.6.6/Dockerfile
+++ b/.dist/versions/master/play/5.6.6/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,107 +197,104 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.0 > /dev/null 2>&1 &
@@ -324,20 +327,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -346,11 +347,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 7.4
     && sudo apt-get install -y php7.4-dev \
     && cd /var/www \
@@ -360,7 +359,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -378,7 +376,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -396,7 +393,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -406,7 +402,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -450,12 +445,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -476,20 +468,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.4/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.2/mods-available/mailcatcher.ini && \
@@ -502,7 +493,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -510,12 +500,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -566,15 +551,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
@@ -584,6 +565,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.6.7/Dockerfile
+++ b/.dist/versions/master/play/5.6.7/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,107 +197,104 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.2 > /dev/null 2>&1 &
@@ -324,20 +327,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -346,11 +347,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 7.4
     && sudo apt-get install -y php7.4-dev \
     && cd /var/www \
@@ -360,7 +359,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -378,7 +376,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -396,7 +393,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -406,7 +402,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -450,12 +445,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -476,20 +468,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.4/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.2/mods-available/mailcatcher.ini && \
@@ -502,7 +493,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -510,12 +500,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -566,15 +551,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
@@ -584,6 +565,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.6.8/Dockerfile
+++ b/.dist/versions/master/play/5.6.8/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,107 +197,104 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.2 > /dev/null 2>&1 &
@@ -324,20 +327,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -346,11 +347,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 7.4
     && sudo apt-get install -y php7.4-dev \
     && cd /var/www \
@@ -360,7 +359,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -378,7 +376,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -396,7 +393,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -406,7 +402,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -450,12 +445,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -476,20 +468,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.4/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.2/mods-available/mailcatcher.ini && \
@@ -502,7 +493,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -510,12 +500,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -566,15 +551,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
@@ -584,6 +565,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.6.9/Dockerfile
+++ b/.dist/versions/master/play/5.6.9/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,107 +197,104 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.2 > /dev/null 2>&1 &
@@ -324,20 +327,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -346,11 +347,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 7.4
     && sudo apt-get install -y php7.4-dev \
     && cd /var/www \
@@ -360,7 +359,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -378,7 +376,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -396,7 +393,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -406,7 +402,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -450,12 +445,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -476,20 +468,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.4/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/7.2/mods-available/mailcatcher.ini && \
@@ -502,7 +493,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -510,12 +500,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -566,15 +551,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/7.4/fpm/conf.d/20-tideways.ini \
@@ -584,6 +565,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.0-rc1/Dockerfile
+++ b/.dist/versions/master/play/5.7.0-rc1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.0-rc2/Dockerfile
+++ b/.dist/versions/master/play/5.7.0-rc2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.0/Dockerfile
+++ b/.dist/versions/master/play/5.7.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.1/Dockerfile
+++ b/.dist/versions/master/play/5.7.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.10/Dockerfile
+++ b/.dist/versions/master/play/5.7.10/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.11/Dockerfile
+++ b/.dist/versions/master/play/5.7.11/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.12/Dockerfile
+++ b/.dist/versions/master/play/5.7.12/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.13/Dockerfile
+++ b/.dist/versions/master/play/5.7.13/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.14/Dockerfile
+++ b/.dist/versions/master/play/5.7.14/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.15/Dockerfile
+++ b/.dist/versions/master/play/5.7.15/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.16-rc/Dockerfile
+++ b/.dist/versions/master/play/5.7.16-rc/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.16/Dockerfile
+++ b/.dist/versions/master/play/5.7.16/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.17/Dockerfile
+++ b/.dist/versions/master/play/5.7.17/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.18/Dockerfile
+++ b/.dist/versions/master/play/5.7.18/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -619,12 +611,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -646,20 +636,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +664,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +671,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +722,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +742,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.19/Dockerfile
+++ b/.dist/versions/master/play/5.7.19/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,228 +197,225 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -445,20 +448,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -467,11 +468,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.3
     && sudo apt-get install -y php8.3-dev \
     && cd /var/www \
@@ -481,7 +480,6 @@ RUN cd /var/www \
     && rm -rf 3.3.2.zip \
     && mv xdebug-3.3.2 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
     && sudo make \
@@ -499,7 +497,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -517,7 +514,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -535,7 +531,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -553,7 +548,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -571,7 +565,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -589,7 +582,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -599,7 +591,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -674,12 +665,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -701,20 +690,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -731,7 +719,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -739,12 +726,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -795,15 +777,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
@@ -821,6 +799,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.2/Dockerfile
+++ b/.dist/versions/master/play/5.7.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.3/Dockerfile
+++ b/.dist/versions/master/play/5.7.3/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.4/Dockerfile
+++ b/.dist/versions/master/play/5.7.4/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.5/Dockerfile
+++ b/.dist/versions/master/play/5.7.5/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.6/Dockerfile
+++ b/.dist/versions/master/play/5.7.6/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.7/Dockerfile
+++ b/.dist/versions/master/play/5.7.7/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.8/Dockerfile
+++ b/.dist/versions/master/play/5.7.8/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/5.7.9/Dockerfile
+++ b/.dist/versions/master/play/5.7.9/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -45,8 +48,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
@@ -71,22 +72,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -96,12 +104,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -153,10 +161,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -171,8 +178,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -191,199 +197,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.0 > /dev/null 2>&1 &
@@ -416,20 +419,18 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 
     && apt-get install -y git
 
@@ -438,11 +439,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 RUN cd /var/www \
-    && apt-get update \
     # install xdebug for php 8.2
     && sudo apt-get install -y php8.2-dev \
     && cd /var/www \
@@ -452,7 +451,6 @@ RUN cd /var/www \
     && rm -rf 3.2.0.zip \
     && mv xdebug-3.2.0 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
     && sudo make \
@@ -470,7 +468,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.1 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
     && sudo make \
@@ -488,7 +485,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize8.0 \
     && sudo ./configure --with-php-config=/usr/bin/php-config8.0 \
     && sudo make \
@@ -506,7 +502,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.4 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.4 \
     && sudo make \
@@ -524,7 +519,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.3 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.3 \
     && sudo make \
@@ -542,7 +536,6 @@ RUN cd /var/www \
     && rm -rf 3.1.4.zip \
     && mv xdebug-3.1.4 xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize7.2 \
     && sudo ./configure --with-php-config=/usr/bin/php-config7.2 \
     && sudo make \
@@ -552,7 +545,6 @@ RUN cd /var/www \
     && sudo phpize7.2 --clean \
     && sudo apt-get remove -y php7.2-dev \
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 
@@ -620,12 +612,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -646,20 +635,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -675,7 +663,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -683,12 +670,7 @@ COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
 
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -739,15 +721,11 @@ RUN echo "" \
 
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 && cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
@@ -763,6 +741,8 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 && cat /tmp/tideways.ini >| /etc/php/7.2/fpm/conf.d/20-tideways.ini \
 && cat /tmp/tideways.ini >| /etc/php/7.2/cli/conf.d/20-tideways.ini \
     && rm -rf /tmp/tideways.ini
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin

--- a/.dist/versions/master/play/6.1.0/Dockerfile
+++ b/.dist/versions/master/play/6.1.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.1.1/Dockerfile
+++ b/.dist/versions/master/play/6.1.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.1.2/Dockerfile
+++ b/.dist/versions/master/play/6.1.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.1.3/Dockerfile
+++ b/.dist/versions/master/play/6.1.3/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.1.4/Dockerfile
+++ b/.dist/versions/master/play/6.1.4/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.1.5/Dockerfile
+++ b/.dist/versions/master/play/6.1.5/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.1.6/Dockerfile
+++ b/.dist/versions/master/play/6.1.6/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.2.0-rc1/Dockerfile
+++ b/.dist/versions/master/play/6.2.0-rc1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.2.0/Dockerfile
+++ b/.dist/versions/master/play/6.2.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.2.1/Dockerfile
+++ b/.dist/versions/master/play/6.2.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.2.2/Dockerfile
+++ b/.dist/versions/master/play/6.2.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.2.3/Dockerfile
+++ b/.dist/versions/master/play/6.2.3/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.3.0.0/Dockerfile
+++ b/.dist/versions/master/play/6.3.0.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.3.0.1/Dockerfile
+++ b/.dist/versions/master/play/6.3.0.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.3.0.2/Dockerfile
+++ b/.dist/versions/master/play/6.3.0.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.3.1.0/Dockerfile
+++ b/.dist/versions/master/play/6.3.1.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.3.1.1/Dockerfile
+++ b/.dist/versions/master/play/6.3.1.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.3.2.0/Dockerfile
+++ b/.dist/versions/master/play/6.3.2.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.3.2.1/Dockerfile
+++ b/.dist/versions/master/play/6.3.2.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.3.3.0/Dockerfile
+++ b/.dist/versions/master/play/6.3.3.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.3.3.1/Dockerfile
+++ b/.dist/versions/master/play/6.3.3.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.3.4.0/Dockerfile
+++ b/.dist/versions/master/play/6.3.4.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.3.4.1/Dockerfile
+++ b/.dist/versions/master/play/6.3.4.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.3.5.0/Dockerfile
+++ b/.dist/versions/master/play/6.3.5.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.3.5.1/Dockerfile
+++ b/.dist/versions/master/play/6.3.5.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.3.5.2/Dockerfile
+++ b/.dist/versions/master/play/6.3.5.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.3.5.3/Dockerfile
+++ b/.dist/versions/master/play/6.3.5.3/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.3.5.4/Dockerfile
+++ b/.dist/versions/master/play/6.3.5.4/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,199 +173,196 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.3/cli/conf.d/01-general-cli.ini \
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 
 && cat /tmp/general.ini >| /etc/php/7.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -390,14 +395,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -406,7 +409,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -421,12 +423,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -447,20 +446,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -476,7 +474,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -517,7 +514,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -531,6 +530,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.0.0-rc1/Dockerfile
+++ b/.dist/versions/master/play/6.4.0.0-rc1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.0.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.0.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.1.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.1.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.1.1/Dockerfile
+++ b/.dist/versions/master/play/6.4.1.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.1.2/Dockerfile
+++ b/.dist/versions/master/play/6.4.1.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.10.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.10.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.10.1/Dockerfile
+++ b/.dist/versions/master/play/6.4.10.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.11.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.11.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.11.1/Dockerfile
+++ b/.dist/versions/master/play/6.4.11.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.12.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.12.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.13.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.13.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.14.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.14.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.15.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.15.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.15.1/Dockerfile
+++ b/.dist/versions/master/play/6.4.15.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.15.2/Dockerfile
+++ b/.dist/versions/master/play/6.4.15.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.16.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.16.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.16.1/Dockerfile
+++ b/.dist/versions/master/play/6.4.16.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.17.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.17.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.17.1/Dockerfile
+++ b/.dist/versions/master/play/6.4.17.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.17.2/Dockerfile
+++ b/.dist/versions/master/play/6.4.17.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.18.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.18.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.18.1/Dockerfile
+++ b/.dist/versions/master/play/6.4.18.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.19.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.19.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.2.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.2.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.2.1/Dockerfile
+++ b/.dist/versions/master/play/6.4.2.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.20.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.20.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.20.1/Dockerfile
+++ b/.dist/versions/master/play/6.4.20.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.20.2/Dockerfile
+++ b/.dist/versions/master/play/6.4.20.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.3.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.3.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.3.1/Dockerfile
+++ b/.dist/versions/master/play/6.4.3.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.4.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.4.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.4.1/Dockerfile
+++ b/.dist/versions/master/play/6.4.4.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.5.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.5.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.5.1/Dockerfile
+++ b/.dist/versions/master/play/6.4.5.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.6.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.6.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.6.1/Dockerfile
+++ b/.dist/versions/master/play/6.4.6.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.7.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.7.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.8.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.8.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.8.1/Dockerfile
+++ b/.dist/versions/master/play/6.4.8.1/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.8.2/Dockerfile
+++ b/.dist/versions/master/play/6.4.8.2/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.4.9.0/Dockerfile
+++ b/.dist/versions/master/play/6.4.9.0/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
+
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
 
@@ -45,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -70,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -127,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -145,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -165,135 +173,134 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.0/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.0/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.0/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/7.4/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/7.4/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/7.4/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php7.4 > /dev/null 2>&1 &
@@ -326,14 +333,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -342,7 +347,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
 
 ## ***********************************************************************
@@ -357,12 +361,9 @@ RUN echo debconf mysql-server/root_password_again password root | debconf-set-se
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf
@@ -383,20 +384,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.0/mods-available/mailcatcher.ini && \
@@ -410,7 +410,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -451,7 +450,9 @@ ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
 
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
+
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -465,6 +466,8 @@ RUN chown www-data:www-data -R /var/www/scripts && \
     #make sure for the whole installation xdebug is off for performance
     sh /var/www/scripts/bin/xdebug_disable.sh && \
     chmod 755 /*.sh
+
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 ## ***********************************************************************
 ##  INSTALL SHOPWARE

--- a/.dist/versions/master/play/6.5.0.0/Dockerfile
+++ b/.dist/versions/master/play/6.5.0.0/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.0.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.0.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.1.0/Dockerfile
+++ b/.dist/versions/master/play/6.5.1.0/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.1.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.1.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.1.1/Dockerfile
+++ b/.dist/versions/master/play/6.5.1.1/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.1.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.1.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.2.0/Dockerfile
+++ b/.dist/versions/master/play/6.5.2.0/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.2.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.2.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.2.1/Dockerfile
+++ b/.dist/versions/master/play/6.5.2.1/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.2.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.2.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.3.0/Dockerfile
+++ b/.dist/versions/master/play/6.5.3.0/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.3.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.3.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.3.1/Dockerfile
+++ b/.dist/versions/master/play/6.5.3.1/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.3.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.3.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.3.2/Dockerfile
+++ b/.dist/versions/master/play/6.5.3.2/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.3.2
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.3.2" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.3.3/Dockerfile
+++ b/.dist/versions/master/play/6.5.3.3/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.3.3
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.3.3" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.4.0/Dockerfile
+++ b/.dist/versions/master/play/6.5.4.0/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.4.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.4.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.4.1/Dockerfile
+++ b/.dist/versions/master/play/6.5.4.1/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.4.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.4.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.5.0/Dockerfile
+++ b/.dist/versions/master/play/6.5.5.0/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.5.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.5.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.5.1/Dockerfile
+++ b/.dist/versions/master/play/6.5.5.1/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.5.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.5.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.5.2/Dockerfile
+++ b/.dist/versions/master/play/6.5.5.2/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.5.2
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.5.2" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.6.0/Dockerfile
+++ b/.dist/versions/master/play/6.5.6.0/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.6.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.6.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.6.1/Dockerfile
+++ b/.dist/versions/master/play/6.5.6.1/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.6.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.6.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.7.0/Dockerfile
+++ b/.dist/versions/master/play/6.5.7.0/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.7.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.7.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.7.1/Dockerfile
+++ b/.dist/versions/master/play/6.5.7.1/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.7.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.7.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.7.2/Dockerfile
+++ b/.dist/versions/master/play/6.5.7.2/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.7.2
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.7.2" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.7.3/Dockerfile
+++ b/.dist/versions/master/play/6.5.7.3/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.7.3
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.7.3" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.7.4/Dockerfile
+++ b/.dist/versions/master/play/6.5.7.4/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.7.4
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.7.4" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.8.0/Dockerfile
+++ b/.dist/versions/master/play/6.5.8.0/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.8.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.8.1/Dockerfile
+++ b/.dist/versions/master/play/6.5.8.1/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.8.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.8.10/Dockerfile
+++ b/.dist/versions/master/play/6.5.8.10/Dockerfile
@@ -35,465 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.10
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.8.10" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -505,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -530,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -587,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -605,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -625,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -750,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -772,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -875,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -902,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -928,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -975,41 +413,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1076,33 +483,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.8.11/Dockerfile
+++ b/.dist/versions/master/play/6.5.8.11/Dockerfile
@@ -35,465 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.11
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.8.11" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -505,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -530,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -587,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -605,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -625,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -750,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -772,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -875,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -902,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -928,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -975,41 +413,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1076,33 +483,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.8.12/Dockerfile
+++ b/.dist/versions/master/play/6.5.8.12/Dockerfile
@@ -35,465 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.12
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.8.12" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -505,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -530,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -587,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -605,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -625,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -750,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -772,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -875,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -902,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -928,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -975,41 +413,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1076,33 +483,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.8.2/Dockerfile
+++ b/.dist/versions/master/play/6.5.8.2/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.2
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.8.2" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.8.3/Dockerfile
+++ b/.dist/versions/master/play/6.5.8.3/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.3
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.8.3" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.8.4/Dockerfile
+++ b/.dist/versions/master/play/6.5.8.4/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.4
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.8.4" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.8.5/Dockerfile
+++ b/.dist/versions/master/play/6.5.8.5/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.5
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.8.5" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.8.6/Dockerfile
+++ b/.dist/versions/master/play/6.5.8.6/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.6
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.8.6" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.8.7/Dockerfile
+++ b/.dist/versions/master/play/6.5.8.7/Dockerfile
@@ -35,459 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.1-fpm stop > /dev/null 2>&1 && \
-    service php8.1-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 18 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 18 \
-    && nvm alias default 18  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.7
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.8.7" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.1
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 18
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -499,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -524,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -581,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -599,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -619,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.1 > /dev/null 2>&1 &
@@ -744,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -766,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -869,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -896,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -922,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -963,41 +407,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 18 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1064,33 +477,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.8.8/Dockerfile
+++ b/.dist/versions/master/play/6.5.8.8/Dockerfile
@@ -35,465 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.8
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.8.8" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -505,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -530,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -587,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -605,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -625,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -750,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -772,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -875,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -902,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -928,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -975,41 +413,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1076,33 +483,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.5.8.9/Dockerfile
+++ b/.dist/versions/master/play/6.5.8.9/Dockerfile
@@ -35,465 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
-    #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.5.8.9
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.5.8.9" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -505,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -530,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -587,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -605,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -625,99 +173,98 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.1/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.1/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.1/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -750,20 +297,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -772,97 +311,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-    # install xdebug for php 8.1
-    && sudo apt-get install -y php8.1-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.1.4.zip \
-    && unzip 3.1.4.zip \
-    && rm -rf 3.1.4.zip \
-    && mv xdebug-3.1.4 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.1 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.1 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20210902/xdebug_8.1.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.1 --clean \
-    && sudo apt-get remove -y php8.1-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.1/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20210902/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.1/g' /etc/php/8.1/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -875,12 +324,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -902,20 +349,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.1/mods-available/mailcatcher.ini && \
@@ -928,20 +374,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -975,41 +413,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.1/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -1076,33 +483,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.6.0.0/Dockerfile
+++ b/.dist/versions/master/play/6.6.0.0/Dockerfile
@@ -35,432 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.0.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.6.0.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -472,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -497,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -554,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -572,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -592,67 +173,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -685,20 +265,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -707,71 +279,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -784,12 +292,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -811,20 +317,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -836,20 +341,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -883,39 +380,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -976,33 +444,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.6.0.1/Dockerfile
+++ b/.dist/versions/master/play/6.6.0.1/Dockerfile
@@ -35,432 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.0.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.6.0.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -472,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -497,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -554,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -572,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -592,67 +173,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -685,20 +265,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -707,71 +279,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -784,12 +292,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -811,20 +317,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -836,20 +341,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -883,39 +380,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -976,33 +444,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.6.0.2/Dockerfile
+++ b/.dist/versions/master/play/6.6.0.2/Dockerfile
@@ -35,432 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.0.2
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.6.0.2" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -472,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -497,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -554,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -572,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -592,67 +173,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -685,20 +265,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -707,71 +279,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -784,12 +292,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -811,20 +317,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -836,20 +341,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -883,39 +380,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -976,33 +444,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.6.1.0/Dockerfile
+++ b/.dist/versions/master/play/6.6.1.0/Dockerfile
@@ -35,432 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.1.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.6.1.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -472,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -497,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -554,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -572,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -592,67 +173,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -685,20 +265,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -707,71 +279,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -784,12 +292,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -811,20 +317,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -836,20 +341,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -883,39 +380,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -976,33 +444,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.6.1.1/Dockerfile
+++ b/.dist/versions/master/play/6.6.1.1/Dockerfile
@@ -35,432 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.1.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.6.1.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -472,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -497,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -554,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -572,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -592,67 +173,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -685,20 +265,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -707,71 +279,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -784,12 +292,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -811,20 +317,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -836,20 +341,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -883,39 +380,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -976,33 +444,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.6.1.2/Dockerfile
+++ b/.dist/versions/master/play/6.6.1.2/Dockerfile
@@ -35,432 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.1.2
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.6.1.2" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -472,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -497,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -554,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -572,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -592,67 +173,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -685,20 +265,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -707,71 +279,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -784,12 +292,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -811,20 +317,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -836,20 +341,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -883,39 +380,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -976,33 +444,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.6.2.0/Dockerfile
+++ b/.dist/versions/master/play/6.6.2.0/Dockerfile
@@ -35,432 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.2.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.6.2.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -472,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -497,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -554,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -572,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -592,67 +173,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -685,20 +265,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -707,71 +279,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -784,12 +292,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -811,20 +317,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -836,20 +341,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -883,39 +380,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -976,33 +444,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.6.3.0/Dockerfile
+++ b/.dist/versions/master/play/6.6.3.0/Dockerfile
@@ -35,432 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.3.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.6.3.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -472,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -497,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -554,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -572,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -592,67 +173,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -685,20 +265,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -707,71 +279,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -784,12 +292,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -811,20 +317,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -836,20 +341,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -883,39 +380,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -976,33 +444,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.6.3.1/Dockerfile
+++ b/.dist/versions/master/play/6.6.3.1/Dockerfile
@@ -35,432 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.3.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.6.3.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -472,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -497,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -554,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -572,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -592,67 +173,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -685,20 +265,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -707,71 +279,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -784,12 +292,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -811,20 +317,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -836,20 +341,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -883,39 +380,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -976,33 +444,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.6.4.0/Dockerfile
+++ b/.dist/versions/master/play/6.6.4.0/Dockerfile
@@ -35,432 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.4.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.6.4.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -472,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -497,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -554,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -572,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -592,67 +173,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -685,20 +265,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -707,71 +279,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -784,12 +292,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -811,20 +317,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -836,20 +341,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -883,39 +380,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -976,33 +444,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.6.4.1/Dockerfile
+++ b/.dist/versions/master/play/6.6.4.1/Dockerfile
@@ -35,432 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.4.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.6.4.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -472,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -497,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -554,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -572,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -592,67 +173,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -685,20 +265,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -707,71 +279,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -784,12 +292,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -811,20 +317,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -836,20 +341,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -883,39 +380,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -976,33 +444,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.6.5.0/Dockerfile
+++ b/.dist/versions/master/play/6.6.5.0/Dockerfile
@@ -35,432 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.5.0
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.6.5.0" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -472,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -497,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -554,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -572,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -592,67 +173,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -685,20 +265,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -707,71 +279,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -784,12 +292,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -811,20 +317,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -836,20 +341,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -883,39 +380,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -976,33 +444,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/6.6.5.1/Dockerfile
+++ b/.dist/versions/master/play/6.6.5.1/Dockerfile
@@ -35,432 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: 6.6.5.1
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:6.6.5.1" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -472,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -497,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -554,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -572,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -592,67 +173,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -685,20 +265,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -707,71 +279,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -784,12 +292,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -811,20 +317,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -836,20 +341,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -883,39 +380,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -976,33 +444,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.dist/versions/master/play/latest/Dockerfile
+++ b/.dist/versions/master/play/latest/Dockerfile
@@ -35,432 +35,8 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
 
-ENV SW_CURRENCY 'not-set'
-RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
-
-ENV SW_API_ACCESS_KEY 'not-set'
-RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
-
-## ***********************************************************************
-##  BASE REQUIREMENTS
-## ***********************************************************************
-RUN apt-get update \
-        && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
-    && mkdir /var/run/sshd \
-    # TIMEZONE SETTINGS
-    # otherwise we would have an interactive input dialog
-    && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
-        && apt-get install -y tzdata \
-    && dpkg-reconfigure --frontend noninteractive tzdata  \
-     \
-        && apt-get install -y xdg-utils \
-            && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
-    && pecl install -f libsodium \
-    && apt-get remove -y php-pear \
-    && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-## ***********************************************************************
-##  USER MANAGEMENT
-## ***********************************************************************
-# set easy root pwd for dev purpose
-RUN echo "root:root" | chpasswd \
-    # set password for www-data, and also
-    # avoid shell login (we have a separate user for that)
-    && echo 'www-data:www-data' | chpasswd \
-    && usermod -s /usr/sbin/nologin www-data \
-    # this option makes sure to avoid root SSH login
-    # we just replace our lines with nothing
-    && sed -i 's/PermitRootLogin without-password//' /etc/ssh/sshd_config \
-    && sed -i 's/PermitRootLogin prohibit-password//' /etc/ssh/sshd_config \
-    # allow root and sudo group to run sudo without password
-    && sed -i /etc/sudoers -re 's/^%sudo.*/%sudo ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    && sed -i /etc/sudoers -re 's/^root.*/root ALL=(ALL:ALL) NOPASSWD: ALL/g' \
-    # remove include directory
-    && sed -i /etc/sudoers -re 's/^#includedir.*/## **Removed the include directive** ##"/g'
-
-## ***********************************************************************
-## creates a new user as www-data alias and adds it to the sudo group
-## along with privileges to run sudo without password
-## params:
-#       - string user
-#       - string pwd
-#       - bool sudo
-## ***********************************************************************
-RUN adduser --disabled-password --uid 5577 --gecos "" --ingroup www-data dockware \
-    && usermod -m -d /var/www dockware | true \
-    && echo "dockware:dockware" | chpasswd \
-        && usermod -a -G sudo dockware \
-    # allow sudo without pwd and dont require tty (for entrypoint commands)
-    && echo "Defaults:dockware !requiretty" >> /etc/sudoers \
-        && sed -i 's/dockware:x:5577:33:/dockware:x:33:33:/g' /etc/passwd
-RUN echo 'AllowUsers dockware' >> /etc/ssh/sshd_config
-
-ENV BASH_ENV /var/www/.bashrc
-
-RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
-    # -------------------------------------------------
-    && chown 33:33 /var/www/.bashrc \
-    # -------------------------------------------------
-    && echo "export BASH_ENV=${BASH_ENV}" >> /etc/profile
-
-## ***********************************************************************
-##  APACHE INSTALLATION
-## ***********************************************************************
-#this conf is needed for enconf command ...
-ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
-
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
-    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
-    && a2enmod headers \
-    && a2enmod rewrite \
-    && a2enmod expires \
-    && a2enmod proxy \
-    && a2enmod proxy_http \
-    && a2enmod proxy_wstunnel \
-    && a2enmod actions \
-    && a2enmod fcgid \
-    && a2enmod alias \
-    && a2enmod proxy_fcgi \
-    && a2enmod http2 \
-    && sudo a2enconf http2 \
-    && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
-ADD ./config/apache/ports.conf /etc/apache2/ports.conf
-ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
-
-# create a new id_rsa for the www-data dockeruser.
-# thus we have a SSH Key for connections out of the box
-
-RUN mkdir -p /var/www/.ssh \
-    && rm -rf /var/www/.ssh/id_rsa; true  \
-    && rm -rf /var/www/.ssh/id_rsa.pub; true  \
-    && ssh-keygen -t rsa -b 4096 -f /var/www/.ssh/id_rsa -C "Dockware Container" -P ""  \
-    && chown -R www-data:www-data /var/www/.ssh \
-    && chmod 0700 /var/www/.ssh
-
-## ***********************************************************************
-##  PHP INSTALLATION
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
-    && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
-    # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
-&& cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
-&& cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
-&& cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
-# remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-#make sure the installation runs also in default php version
-RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
-# make sure the installation runs using our default php version
-RUN service php8.3-fpm stop > /dev/null 2>&1 && \
-    service php8.3-fpm start && \
-    sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 \
-
-# make sure our php user has rights on the session
-&& chown www-data:www-data -R /var/lib/php/sessions
-
-# remove the standard apache index file
-RUN mkdir -p /var/www/html \
-    && rm -rf /var/www/html/* \
-    && chown -R www-data:www-data /var/www/html \
-    && sudo -u www-data sh -c 'mkdir -p /var/www/html/public'
-
-# make sure the configured log folder exists and is writeable
-RUN chmod -R 0777 /var/www \
-    && chgrp -R www-data /var/log/apache2 \
-    && mkdir -p /var/log/mysql \
-    && chgrp -R www-data /var/log/mysql\
-    && mkdir /var/log/php -p  \
-    && touch /var/log/php/cli_errors.log  \
-    && touch /var/log/php/fpm_errors.log  \
-    && chown -R www-data:www-data /var/log/php  \
-    && chmod 0755 /var/log/php
-
-## ***********************************************************************
-##  MOD_SSL
-##  create SSL certificate
-## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
-    && a2enmod ssl \
-    && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-RUN apt-get update \
-
-    && apt-get install -y git
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --version=2.2.9 --quiet \
-    # prepare "global" composer directory for www-data
-    && mkdir -p /var/www/.composer \
-    && export COMPOSER_HOME="/var/www/.composer" \
-    && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && mv /tmp/composer.phar /usr/local/bin/composer
-
-## ***********************************************************************
-##  MYSQL INSTALL
-## ***********************************************************************
-
-# prepare environment variables to allow a
-# quiet install of the mysql server
-# this sets the root password to root without user prompts
-RUN echo debconf mysql-server/root_password password root | debconf-set-selections \
-    && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive \
-    # install mysql server
-    && apt-get update \
-    && apt-get install -y -q mysql-server-8.0 \
-    # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    # i dont know why, but this is suddenly required
-    && chmod 0444 /etc/mysql/my.cnf \
-    && service mysql start \
-    #creat ethe user for % and also localhost as otherwise you qould have to connect to 127.0.0.1 and not localhost as mysql treats this different
-    && sudo mysql --user=root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && sudo mysql --user=root --password=root -e "CREATE USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root';GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;FLUSH PRIVILEGES;use mysql;select user from user;" \
-    && service mysql restart
-
-# copy our custom configuration to the image
-ADD ./config/mysql/my8.cnf /etc/mysql/my.cnf
-
-## ***********************************************************************
-##  ADMINER
-## ***********************************************************************
-
-RUN mkdir /usr/share/adminer \
-    && wget "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php" -O /usr/share/adminer/latest.php \
-    && ln -s /usr/share/adminer/latest.php /usr/share/adminer/adminer.php \
-    && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
-    && a2enconf adminer.conf
-
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
-    && gem install net-protocol -v 0.1.2 \
-    && gem install net-smtp -v 0.3.0 \
-    && gem install net-imap -v 0.2.2 \
-    && gem install sqlite3 -v 1.3.4 \
-    && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
-RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
-echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
-    echo ""
-
-RUN mkdir -p /var/www/pimpmylog && \
-    wget -O - https://github.com/potsky/PimpMyLog/tarball/master | tar xzf - && \
-    mv potsky-PimpMyLog-* /var/www/pimpmylog && \
-    mv /var/www/pimpmylog/potsky-PimpMyLog-2fed8c1/* /var/www/pimpmylog && \
-    rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
-
-COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
-
-# apply our custom file with fixes for PHP 8
-# its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
-COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
-
-RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN ls -la \
-    && mkdir "/var/www/.nvm" \
-    && export NVM_DIR="/var/www/.nvm" \
-    # -----------------------------------------------------------------------------------------
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
-    # -----------------------------------------------------------------------------------------
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    # -----------------------------------------------------------------------------------------
-    && nvm install 20 \
-    && nvm install 18 \
-    && nvm install 16 \
-    && nvm install 14 \
-    && nvm install 12 \
-    # -----------------------------------------------------------------------------------------
-    # we have to install yarn in additional node versions
-    # otherwise it won't be found after a nvm switch
-    && nvm use 20 && npm install -g yarn \
-    && nvm use 18 && npm install -g yarn \
-    && nvm use 16 && npm install -g yarn \
-    && nvm use 14 && npm install -g yarn \
-    && nvm use 12 && npm install -g yarn \
-    # -----------------------------------------------------------------------------------------
-    && nvm use 20 \
-    && nvm alias default 20  \
-    # -----------------------------------------------------------------------------------------
-    && echo ""
-
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
-
-RUN echo "" \
-
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/scripts/makefile /var/www/makefile
-COPY ./assets/scripts/bin /var/www/scripts/bin
-COPY ./assets/scripts/cron /var/www/scripts/cron
-
-COPY ./assets/shopware6/files /var/www/scripts/shopware6
-
-ADD entrypoint.sh /entrypoint.sh
-
-RUN chown www-data:www-data -R /var/www/scripts && \
-    #make sure for the whole installation xdebug is off for performance
-    sh /var/www/scripts/bin/xdebug_disable.sh && \
-    chmod 755 /*.sh
-
-# Official Dockware Image
-# Tag: latest
-# Copyright 2022 dasistweb GmbH
-#
-FROM ubuntu:22.04
-LABEL title="Dockware play:latest" \
-      version="1.7.0" \
-      maintainer="dasistweb GmbH"
-
-# remember build-date
-RUN date >/build-date.txt && \
-    mkdir -p /var/www && \
-    mkdir -p /var/www/scripts
-
-# add our changelog to the containers
-ADD ./assets/CHANGELOG.md /var/www/CHANGELOG.md
-
-## ***********************************************************************
-##  IMAGE VARIABLES
-## ***********************************************************************
-ENV TZ Europe/Berlin
-ENV PHP_VERSION 8.3
-ENV APACHE_DOCROOT /var/www/html/public
-ENV SW_TASKS_ENABLED 0
-ENV COMPOSER_VERSION not-set
-ENV NODE_VERSION 20
-ENV SHOP_DOMAIN localhost
-ENV RECOVERY_MODE 0
-RUN echo "export TZ=${TZ}" >> /etc/profile \
- && echo "export PHP_VERSION=${PHP_VERSION}" >> /etc/profile \
- && echo "export APACHE_DOCROOT=${APACHE_DOCROOT}" >> /etc/profile \
- && echo "export SW_TASKS_ENABLED=${SW_TASKS_ENABLED}" >> /etc/profile \
- && echo "export COMPOSER_VERSION=${COMPOSER_VERSION}" >> /etc/profile \
- && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
- && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
- && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
-
-ENV SSH_USER not-set
-ENV SSH_PWD not-set
-ENV XDEBUG_REMOTE_HOST "host.docker.internal"
-ENV XDEBUG_CONFIG "idekey=PHPSTORM"
-ENV PHP_IDE_CONFIG "serverName=localhost"
-ENV XDEBUG_ENABLED 0
-ENV FILEBEAT_ENABLED 0
-ENV TIDEWAYS_KEY not-set
-ENV TIDEWAYS_ENV production
-
 COPY ./config/php/general.ini /tmp/general.ini
 COPY ./config/php/cli.ini /tmp/cli.ini
-COPY ./config/tideways/tideways.ini /tmp/tideways.ini
-
-RUN echo "export SSH_USER=${SSH_USER}" >> /etc/profile \
- && echo "export SSH_PWD=${SSH_PWD}" >> /etc/profile \
- && echo "export XDEBUG_ENABLED=${XDEBUG_ENABLED}" >> /etc/profile \
- && echo "export XDEBUG_REMOTE_HOST=${XDEBUG_REMOTE_HOST}" >> /etc/profile \
- && echo "export XDEBUG_CONFIG=${XDEBUG_CONFIG}" >> /etc/profile \
- && echo "export PHP_IDE_CONFIG=${PHP_IDE_CONFIG}" >> /etc/profile \
- && echo "export FILEBEAT_ENABLED=${FILEBEAT_ENABLED}" >> /etc/profile \
- && echo "export TIDEWAYS_KEY=${TIDEWAYS_KEY}" >> /etc/profile \
- && echo "export TIDEWAYS_ENV=${TIDEWAYS_ENV}" >> /etc/profile
-
-ENV MYSQL_USER not-set
-ENV MYSQL_PWD not-set
-RUN echo "export MYSQL_USER=${MYSQL_USER}" >> /etc/profile \
-    && echo "export MYSQL_PWD=${MYSQL_PWD}" >> /etc/profile
 
 ENV SW_CURRENCY 'not-set'
 RUN echo "export SW_CURRENCY=${SW_CURRENCY}" >> /etc/profile
@@ -472,22 +48,29 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
         && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -497,12 +80,12 @@ RUN apt-get update \
      \
         && apt-get install -y xdg-utils \
             && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
-            && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+            && echo ""
 
 ## ***********************************************************************
 ##  USER MANAGEMENT
@@ -554,10 +137,9 @@ RUN echo "source /var/www/.nvm/nvm.sh" >> /var/www/.bashrc \
 #this conf is needed for enconf command ...
 ADD ./config/apache/http2.conf /etc/apache2/conf-available/http2.conf
 
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -572,8 +154,7 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 
 ADD ./config/apache/apache2.conf /etc/apache2/apache2.conf
 ADD ./config/apache/ports.conf /etc/apache2/ports.conf
@@ -592,67 +173,66 @@ RUN mkdir -p /var/www/.ssh \
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.3/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.3/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.3/cli/conf.d/01-general-cli.ini \
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \
 && cat /tmp/general.ini >| /etc/php/8.2/fpm/conf.d/01-general.ini \
 && cat /tmp/general.ini >| /etc/php/8.2/cli/conf.d/01-general.ini \
 && cat /tmp/cli.ini >| /etc/php/8.2/cli/conf.d/01-general-cli.ini \
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php8.3 > /dev/null 2>&1 &
@@ -685,20 +265,12 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 
-RUN apt-get update \
-
-    && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+RUN echo "" \
 
     && apt-get install -y git
 
@@ -707,71 +279,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer
-
-RUN cd /var/www \
-    && apt-get update \
-    # install xdebug for php 8.3
-    && sudo apt-get install -y php8.3-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.3.2.zip \
-    && unzip 3.3.2.zip \
-    && rm -rf 3.3.2.zip \
-    && mv xdebug-3.3.2 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.3 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.3 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20230831/xdebug_8.3.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.3 --clean \
-    && sudo apt-get remove -y php8.3-dev \
-    # install xdebug for php 8.2
-    && sudo apt-get install -y php8.2-dev \
-    && cd /var/www \
-    && rm -rf xdebug \
-    && wget https://github.com/xdebug/xdebug/archive/refs/tags/3.2.0.zip \
-    && unzip 3.2.0.zip \
-    && rm -rf 3.2.0.zip \
-    && mv xdebug-3.2.0 xdebug \
-    && cd /var/www/xdebug \
-    && sudo apt-get update \
-    && sudo phpize8.2 \
-    && sudo ./configure --with-php-config=/usr/bin/php-config8.2 \
-    && sudo make \
-    && sudo cp /var/www/xdebug/modules/xdebug.so /usr/lib/php/20220829/xdebug_8.2.so \
-    && make clean \
-    && make distclean \
-    && sudo phpize8.2 --clean \
-    && sudo apt-get remove -y php8.2-dev \
-&& sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-&& sudo rm -rf /var/www/xdebug
-#generate xdebug ini files
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.3/cli/conf.d/20-xdebug.ini
-
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/fpm/conf.d/20-xdebug.ini
-COPY ./config/php/xdebug-3.ini /etc/php/8.2/cli/conf.d/20-xdebug.ini
-
-RUN cd /var/www \
-
-&& sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20230831/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.3/g' /etc/php/8.3/cli/conf.d/20-xdebug.ini \
-
-&& sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/fpm/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP__FOLDER__ID/20220829/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-    && sed -i 's/__PHP_VERSION__/8.2/g' /etc/php/8.2/cli/conf.d/20-xdebug.ini \
-
- && cd /var/www
 
 ## ***********************************************************************
 ##  MYSQL INSTALL
@@ -784,12 +292,10 @@ RUN echo debconf mysql-server/root_password password root | debconf-set-selectio
     && echo debconf mysql-server/root_password_again password root | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \
@@ -811,20 +317,19 @@ RUN mkdir /usr/share/adminer \
     && echo "Alias /adminer.php /usr/share/adminer/adminer.php" | sudo tee /etc/apache2/conf-available/adminer.conf \
     && a2enconf adminer.conf
 
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
 RUN echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.3/mods-available/mailcatcher.ini && \
 echo "sendmail_path = /usr/bin/env $(which catchmail) -f 'local@dockware'" >> /etc/php/8.2/mods-available/mailcatcher.ini && \
     echo ""
@@ -836,20 +341,12 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
 COPY /config/pimpmylog/global.inc.php /var/www/pimpmylog/inc/global.inc.php
 
 RUN chown -R www-data:www-data /var/www/pimpmylog/
-
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN ls -la \
     && mkdir "/var/www/.nvm" \
@@ -883,39 +380,10 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/v$NODE_VERSION/bin:$PATH
 
 RUN echo "" \
-    # -----------------------------------------------------------
-    # we have to reload the correct nvm version otherwise this would destroy it
-    && export NVM_DIR="/var/www/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  \
-    && nvm use 20 \
-    # -----------------------------------------------------------
-    && mkdir /var/www/.npm \
-    && npm config set cache /var/www/.npm \
-    && chown 33:33 /var/www/.npm \
 
-    # navigate to another folder outside shopware to avoid this error: npm ERR! Tracker "idealTree" already exists
-    && cd /var/www && npm install -g grunt-cli \
-    && cd /var/www && npm install grunt --save-dev \
+    && echo ""
 
-    && npm install -g --no-install-recommends yarn \
-    && chown -R www-data:www-data /var/www/.composer \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
-COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
-COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && sudo chmod 0755 /etc/init.d/tideways-daemon \
-
-&& cat /tmp/tideways.ini >| /etc/php/8.3/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.3/cli/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/fpm/conf.d/20-tideways.ini \
-&& cat /tmp/tideways.ini >| /etc/php/8.2/cli/conf.d/20-tideways.ini \
-    && rm -rf /tmp/tideways.ini
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY ./assets/scripts/makefile /var/www/makefile
 COPY ./assets/scripts/bin /var/www/scripts/bin
@@ -976,33 +444,6 @@ RUN sudo service mysql start && \
     mysql --user=root --password=root -e "use shopware; INSERT INTO system_config (id, configuration_key, configuration_value, sales_channel_id, created_at, updated_at) VALUES (X'b3ae4d7111114377af9480c4a0911111', 'core.frw.completedAt', '{\"_value\": \"2019-10-07T10:46:23+00:00\"}', NULL, '2019-10-07 10:46:23.169', NULL);" && \
     # -------------------------------------------------------------------------------------------
     sudo service mysql stop
-
-RUN echo "" && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/friendsofshopware/stable/setup.deb.sh' | sudo -E bash && sudo apt install shopware-cli && \
-    chown 33:33 -R /var/www/html && \
-    mkdir -p /var/www/.npm && chown 33:33 /var/www/.npm -R && \
-    # this is necessary so that our user can
-    # change the default nvm node version
-    # otherwise the persisted node version switch would not work!
-    mkdir -p /var/www/.nvm && chown 33:33 /var/www/.nvm -R && \
-    echo ""
-
-## ***********************************************************************
-## SWITCH TO NORMAL USER (NOT ROOT ANYMORE!)
-## everything down here is now done as our www-data / dockware user
-## just like you would do it manually in the container
-## ***********************************************************************
-
-USER dockware
-
-# make the apache folder the working directory
-WORKDIR /var/www/html
-
-## ***********************************************************************
-##  POST BUILD
-## ***********************************************************************
-
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 
 RUN echo "" && \
     chown 33:33 -R /var/www/html && \

--- a/.github/workflows/cached-build.yml
+++ b/.github/workflows/cached-build.yml
@@ -1,0 +1,174 @@
+name: Build and publish the Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Which version of the image to build'
+        required: true
+        default: 'play'
+      tag:
+        description: 'Which tag of the image to build'
+        required: true
+        default: 'latest'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/${{ github.event.inputs.version }}
+  CONTEXT_PATH: .dist/versions/${{ github.ref_name }}/${{ github.event.inputs.version }}/${{ github.event.inputs.tag }}
+
+jobs:
+  build-arm64-image:
+    runs-on: custom-arm64
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.7
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Set up Docker buildx for cache
+        uses: docker/setup-buildx-action@v3.5.0
+
+      - name: Repository name to lowercase
+        run: |
+          echo "FULL_LOWERCASE_NAME=${REGISTRY}/${IMAGE_NAME@L}" >> "${GITHUB_ENV}"
+
+      - name: Build and push Docker image
+        id: build
+        uses: docker/build-push-action@v6.5.0
+        with:
+          platforms: linux/arm64
+          outputs: type=image,name=${{ env.FULL_LOWERCASE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          context: ${{ env.CONTEXT_PATH }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.FULL_LOWERCASE_NAME }}:buildcache-arm64
+          cache-to: type=registry,ref=${{ env.FULL_LOWERCASE_NAME }}:buildcache-arm64,mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: digests-linux-arm64
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-amd64-image:
+    runs-on: custom-amd64
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.7
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Set up Docker buildx for cache
+        uses: docker/setup-buildx-action@v3.5.0
+
+      - name: Repository name to lowercase
+        run: |
+          echo "FULL_LOWERCASE_NAME=${REGISTRY}/${IMAGE_NAME@L}" >> "${GITHUB_ENV}"
+
+      - name: Build and push Docker image
+        id: build
+        uses: docker/build-push-action@v6.5.0
+        with:
+          platforms: linux/amd64
+          outputs: type=image,name=${{ env.FULL_LOWERCASE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          context: ${{ env.CONTEXT_PATH }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.FULL_LOWERCASE_NAME }}:buildcache-amd64
+          cache-to: type=registry,ref=${{ env.FULL_LOWERCASE_NAME }}:buildcache-amd64,mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: digests-linux-amd64
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-digests:
+    runs-on: custom-amd64
+    needs: [ build-arm64-image, build-amd64-image ]
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4.1.8
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Repository name to lowercase
+        run: |
+          echo "FULL_LOWERCASE_NAME=${REGISTRY}/${IMAGE_NAME@L}" >> "${GITHUB_ENV}"
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create -t ${{ env.FULL_LOWERCASE_NAME }}:${{ github.event.inputs.tag }} $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.FULL_LOWERCASE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.FULL_LOWERCASE_NAME }}:${{ github.event.inputs.tag }}

--- a/template/Dockerfile.global.sh.twig
+++ b/template/Dockerfile.global.sh.twig
@@ -38,10 +38,12 @@ RUN echo "export TZ=${TZ}" >> /etc/profile \
  && echo "export NODE_VERSION=${NODE_VERSION}" >> /etc/profile \
  && echo "export SHOP_DOMAIN=${SHOP_DOMAIN}" >> /etc/profile \
  && echo "export RECOVERY_MODE=${RECOVERY_MODE}" >> /etc/profile
+
+COPY ./config/php/general.ini /tmp/general.ini
+COPY ./config/php/cli.ini /tmp/cli.ini
 {% endblock %}
 
 {% block image_variables_dev %}
-
 ENV SSH_USER not-set
 ENV SSH_PWD not-set
 ENV XDEBUG_REMOTE_HOST "host.docker.internal"
@@ -52,8 +54,6 @@ ENV FILEBEAT_ENABLED 0
 ENV TIDEWAYS_KEY not-set
 ENV TIDEWAYS_ENV production
 
-COPY ./config/php/general.ini /tmp/general.ini
-COPY ./config/php/cli.ini /tmp/cli.ini
 COPY ./config/tideways/tideways.ini /tmp/tideways.ini
 
 
@@ -92,23 +92,30 @@ RUN echo "export SW_API_ACCESS_KEY=${SW_API_ACCESS_KEY}" >> /etc/profile
 ##  BASE REQUIREMENTS
 ## ***********************************************************************
 RUN apt-get update \
+    && apt-get install -y wget gnupg2 sudo \
+    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
+    && apt-get install -y apt-transport-https \
+    && echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
+    && sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
+    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add
+
+RUN apt-get update
+
+RUN echo "" \
     {% block base %}
     && apt-get install -y gosu \
-    && apt-get install -y sudo \
-    && apt-get install -y wget \
-    && apt-get install -y curl \
-    && apt-get install -y unzip \
-    && apt-get install -y bzip2 \
-    && apt-get install -y ssmtp \
-    && apt-get install -y lsof \
-    && apt-get install -y openssh-server \
-    && apt-get install -y cron \
-    && apt-get install -y vim \
-    && apt-get install -y nano \
-    && apt-get install -y jq \
-    && apt-get install -y gnupg2 \
-    && apt-get install -y gpg-agent \
-    && apt-get install -y chromium-browser \
+                            curl \
+                            unzip \
+                            bzip2 \
+                            ssmtp \
+                            lsof \
+                            openssh-server \
+                            cron \
+                            vim \
+                            nano \
+                            jq \
+                            gpg-agent \
+                            chromium-browser \
     && mkdir /var/run/sshd \
     # TIMEZONE SETTINGS
     # otherwise we would have an interactive input dialog
@@ -122,15 +129,14 @@ RUN apt-get update \
     {% endblock %}
     {% block base_sodium %}
     && apt-get install -y libsodium-dev \
-    && apt-get install -y php-dev \
-    && apt-get install -y php-pear \
+                            php-dev \
+                            php-pear \
     && pecl install -f libsodium \
     && apt-get remove -y php-pear \
     && apt-get remove -y php-dev \
     {% endblock %}
     {% endblock %}
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
+    && echo ""
 
 {% block users %}
 ## ***********************************************************************
@@ -202,7 +208,7 @@ ADD ./config/apache/sites.conf /etc/apache2/sites-enabled/000-default.conf
 ## ***********************************************************************
 ##  PHP INSTALLATION
 ## ***********************************************************************
-RUN apt-get update \
+RUN echo "" \
 {% for key,value in php.versions %}
 {% if value.active == true %}
 {% include "template/components/php/#{ key }/install.sh.twig" %}
@@ -212,8 +218,7 @@ RUN apt-get update \
 {% endif %}
 {% endfor %}
 # remove pecl again
-&& apt-get remove -y dh-php \
-&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+&& apt-get remove -y dh-php
 
 #make sure the installation runs also in default php version
 RUN sudo update-alternatives --set php /usr/bin/php{{ php.default_version }} > /dev/null 2>&1 &
@@ -251,26 +256,24 @@ RUN chmod -R 0777 /var/www \
 ##  MOD_SSL
 ##  create SSL certificate
 ## ***********************************************************************
-RUN apt-get update \
-    && apt-get install -y openssl \
+RUN apt-get install -y openssl \
     && a2enmod ssl \
     && mkdir /etc/apache2/ssl \
-    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost' \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && openssl req -new -x509 -days 365 -sha1 -newkey rsa:2048 -nodes -keyout /etc/apache2/ssl/server.key -out /etc/apache2/ssl/server.crt -subj '/O=Company/OU=Department/CN=localhost'
 {% endblock %}
 
 
 
 {% block components %}
 
-RUN apt-get update \
+RUN echo "" \
 
 {% block components_dev_tools %}
     && apt-get install -y rsync \
-    && apt-get install -y sshpass \
-    && apt-get install -y jpegoptim \
-    && apt-get install -y screen \
-    && apt-get install -y mysql-client \
+                            sshpass \
+                            jpegoptim \
+                            screen \
+                            mysql-client \
 {% endblock %}
 
 {% block components_git %}
@@ -295,14 +298,12 @@ RUN apt-get update \
 
 {% block components_xdebug %}
 RUN cd /var/www \
-    && apt-get update \
 {% for key, value in php.versions %}
 {% if value.active and value.xdebug_version != '' %}
 {% include 'template/components/xdebug/install.sh.twig' with { "php_version" : key,"folder_id" : value.folder_id, "xdebug_tag":value.xdebug_tag} %}
 {% endif %}
 {% endfor %}
 && sudo apt-get install -y zlib1g-dev \
-&& sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
 && sudo rm -rf /var/www/xdebug
 #generate xdebug ini files
 {% for key, value in php.versions %}
@@ -352,7 +353,6 @@ RUN mkdir -p /var/www/pimpmylog && \
     rm -rf /var/www/pimpmylog/potsky-PimpMyLog-*
 
 COPY /config/pimpmylog/config.user.d /var/www/pimpmylog/config.user.d
-COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
 
 # apply our custom file with fixes for PHP 8
 # its used from here: https://github.com/potsky/PimpMyLog/pull/149/files
@@ -362,15 +362,8 @@ RUN chown -R www-data:www-data /var/www/pimpmylog/
 {% endblock %}
 
 {% block components_filebeat %}
-RUN apt-get update \
-    && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-    &&  apt-get install -y apt-transport-https \
-    &&  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list \
-    &&  apt-get update && apt-get install filebeat \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get install -y filebeat
 {% endblock %}
-
-
 
 {% block components_nvm %}
 RUN ls -la \
@@ -429,17 +422,13 @@ RUN echo "" \
     && npm install -g --no-install-recommends yarn \
     && chown -R www-data:www-data /var/www/.composer \
 {% endblock %}
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && echo ""
 
 
 {% block components_tideways %}
 COPY ./assets/tideways/tideways-daemon /etc/init.d/tideways-daemon
 COPY ./config/tideways/tideways-daemon /etc/default/tideways-daemon
-RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version main' | sudo tee /etc/apt/sources.list.d/tideways.list \
-    && sudo wget -qO - https://packages.tideways.com/key.gpg | sudo apt-key add - \
-    && sudo apt-get -y update  \
-    && sudo apt-get -y install tideways-php tideways-daemon  \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+RUN sudo apt-get -y install tideways-php tideways-daemon  \
     && sudo chmod 0755 /etc/init.d/tideways-daemon \
 
 {% for key,value in php.versions %}
@@ -452,7 +441,7 @@ RUN sudo echo 'deb https://packages.tideways.com/apt-packages-main any-version m
 {% endblock %}
 {% endblock %}
 
-
+RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 {% block assets_install %}
 COPY ./assets/scripts/makefile /var/www/makefile
@@ -475,6 +464,10 @@ RUN chown www-data:www-data -R /var/www/scripts && \
 
 
 {% block shopware %}
+
+{% block components_pimpmylog_user_config %}
+COPY /config/pimpmylog/config.user.json /var/www/pimpmylog/config.user.json
+{% endblock %}
 
 {% block shopware_install %}
 ## ***********************************************************************

--- a/template/components/apache2/install.sh.twig
+++ b/template/components/apache2/install.sh.twig
@@ -1,7 +1,6 @@
-RUN apt-get update \
-    && apt-get install -y apache2 \
-    && apt-get install -y libapache2-mod-fcgid \
-    && apt-get install -y software-properties-common \
+RUN apt-get install -y apache2 \
+                            libapache2-mod-fcgid \
+                            software-properties-common \
     && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
     && a2enmod headers \
     && a2enmod rewrite \
@@ -16,6 +15,5 @@ RUN apt-get update \
     && a2enmod http2 \
     && sudo a2enconf http2 \
     && sudo a2dismod mpm_prefork > /dev/null 2>&1 \
-    && sudo a2enmod mpm_event > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && sudo a2enmod mpm_event > /dev/null 2>&1
 

--- a/template/components/composer/v1/install.sh.twig
+++ b/template/components/composer/v1/install.sh.twig
@@ -5,5 +5,4 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && chmod 755 /tmp/composer.phar \
     && mv /tmp/composer.phar /usr/local/bin/composer \
     # install prestissimo for parallel dependency installation (https://github.com/hirak/prestissimo)
-    && cd /var/www/.composer && composer require hirak/prestissimo \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && cd /var/www/.composer && composer require hirak/prestissimo

--- a/template/components/composer/v2/install.sh.twig
+++ b/template/components/composer/v2/install.sh.twig
@@ -3,5 +3,4 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp --ver
     && mkdir -p /var/www/.composer \
     && export COMPOSER_HOME="/var/www/.composer" \
     && chmod 755 /tmp/composer.phar \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && mv /tmp/composer.phar /usr/local/bin/composer

--- a/template/components/mailcatcher/install.sh.twig
+++ b/template/components/mailcatcher/install.sh.twig
@@ -1,14 +1,12 @@
-RUN apt-get update \
-    && apt-get install -y build-essential \
-    && apt-get install -y libsqlite3-dev \
-    && apt-get install -y rubygems \
-    && apt-get install -y ruby-dev \
+RUN apt-get install -y build-essential \
+                            libsqlite3-dev \
+                            rubygems \
+                            ruby-dev \
     && gem install net-protocol -v 0.1.2 \
     && gem install net-smtp -v 0.3.0 \
     && gem install net-imap -v 0.2.2 \
     && gem install sqlite3 -v 1.3.4 \
     && gem install mailcatcher \
-    && phpenmod mailcatcher \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && phpenmod mailcatcher
 
 COPY ./config/ssmtp/ssmtp.conf /etc/ssmtp/ssmtp.conf

--- a/template/components/mysql/5.7/install.sh.twig
+++ b/template/components/mysql/5.7/install.sh.twig
@@ -10,12 +10,9 @@ RUN echo debconf mysql-server/root_password_again password {{ pwd }} | debconf-s
 
 RUN DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server \
     # set requires permissions
-    && usermod -d /var/lib/mysql/ mysql \
-    # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+    && usermod -d /var/lib/mysql/ mysql
 
 # copy our custom configuration to the image
 ADD ./config/mysql/my.cnf /etc/mysql/my.cnf

--- a/template/components/mysql/8.0/install.sh.twig
+++ b/template/components/mysql/8.0/install.sh.twig
@@ -9,12 +9,10 @@ RUN echo debconf mysql-server/root_password password {{ pwd }} | debconf-set-sel
     && echo debconf mysql-server/root_password_again password {{ pwd }} | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive \
     # install mysql server
-    && apt-get update \
     && apt-get install -y -q mysql-server-8.0 \
     # set requires permissions
     && usermod -d /var/lib/mysql/ mysql \
     # cleanup download folders
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     # i dont know why, but this is suddenly required
     && chmod 0444 /etc/mysql/my.cnf \
     && service mysql start \

--- a/template/components/php/5.6/install.sh.twig
+++ b/template/components/php/5.6/install.sh.twig
@@ -1,27 +1,26 @@
-
     && apt-get install -y php5.6-fpm \
-    && apt-get install -y php5.6-apc \
-    && apt-get install -y php5.6-apcu \
-    && apt-get install -y php5.6-curl \
-    && apt-get install -y php5.6-cli \
-    && apt-get install -y php5.6-gd \
-    && apt-get install -y php5.6-json \
-    && apt-get install -y php5.6-ldap \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-pgsql \
-    && apt-get install -y php5.6-gettext \
-    && apt-get install -y php5.6-intl \
-    && apt-get install -y php5.6-xml \
-    && apt-get install -y php5.6-mysql \
-    && apt-get install -y php5.6-mbstring \
-    && apt-get install -y php5.6-zip \
-    && apt-get install -y php5.6-soap \
-    && apt-get install -y php5.6-memcached \
-    && apt-get install -y php5.6-redis \
-    && apt-get install -y php5.6-bcmath \
-    && apt-get install -y php5.6-imap \
-    && apt-get install -y php5.6-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php5.6-geoip \
-    && apt-get install -y php5.6-amqp \
-    && apt-get install -y php5.6-mongo \
+                            php5.6-apc \
+                            php5.6-apcu \
+                            php5.6-curl \
+                            php5.6-cli \
+                            php5.6-gd \
+                            php5.6-json \
+                            php5.6-ldap \
+                            php5.6-mysql \
+                            php5.6-pgsql \
+                            php5.6-gettext \
+                            php5.6-intl \
+                            php5.6-xml \
+                            php5.6-mysql \
+                            php5.6-mbstring \
+                            php5.6-zip \
+                            php5.6-soap \
+                            php5.6-memcached \
+                            php5.6-redis \
+                            php5.6-bcmath \
+                            php5.6-imap \
+                            php5.6-ssh2 \
+                            dh-php \
+                            php5.6-geoip \
+                            php5.6-amqp \
+                            php5.6-mongo \

--- a/template/components/php/7.0/install.sh.twig
+++ b/template/components/php/7.0/install.sh.twig
@@ -1,27 +1,26 @@
-
     && apt-get install -y php7.0-fpm \
-    && apt-get install -y php7.0-apc \
-    && apt-get install -y php7.0-apcu \
-    && apt-get install -y php7.0-curl \
-    && apt-get install -y php7.0-cli \
-    && apt-get install -y php7.0-gd \
-    && apt-get install -y php7.0-json \
-    && apt-get install -y php7.0-ldap \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-pgsql \
-    && apt-get install -y php7.0-gettext \
-    && apt-get install -y php7.0-intl \
-    && apt-get install -y php7.0-xml \
-    && apt-get install -y php7.0-mysql \
-    && apt-get install -y php7.0-mbstring \
-    && apt-get install -y php7.0-zip \
-    && apt-get install -y php7.0-soap \
-    && apt-get install -y php7.0-memcached \
-    && apt-get install -y php7.0-redis \
-    && apt-get install -y php7.0-bcmath \
-    && apt-get install -y php7.0-imap \
-    && apt-get install -y php7.0-ssh2 \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.0-geoip \
-    && apt-get install -y php7.0-amqp \
-    && apt-get install -y php7.0-mongo \
+                            php7.0-apc \
+                            php7.0-apcu \
+                            php7.0-curl \
+                            php7.0-cli \
+                            php7.0-gd \
+                            php7.0-json \
+                            php7.0-ldap \
+                            php7.0-mysql \
+                            php7.0-pgsql \
+                            php7.0-gettext \
+                            php7.0-intl \
+                            php7.0-xml \
+                            php7.0-mysql \
+                            php7.0-mbstring \
+                            php7.0-zip \
+                            php7.0-soap \
+                            php7.0-memcached \
+                            php7.0-redis \
+                            php7.0-bcmath \
+                            php7.0-imap \
+                            php7.0-ssh2 \
+                            dh-php \
+                            php7.0-geoip \
+                            php7.0-amqp \
+                            php7.0-mongo \

--- a/template/components/php/7.1/install.sh.twig
+++ b/template/components/php/7.1/install.sh.twig
@@ -1,29 +1,28 @@
-
     && apt-get install -y php7.1-fpm \
-    && apt-get install -y php7.1-apc \
-    && apt-get install -y php7.1-apcu \
-    && apt-get install -y php7.1-curl \
-    && apt-get install -y php7.1-cli \
-    && apt-get install -y php7.1-gd \
-    && apt-get install -y php7.1-json \
-    && apt-get install -y php7.1-ldap \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-pgsql \
-    && apt-get install -y php7.1-gettext \
-    && apt-get install -y php7.1-intl \
-    && apt-get install -y php7.1-xml \
-    && apt-get install -y php7.1-mysql \
-    && apt-get install -y php7.1-mbstring \
-    && apt-get install -y php7.1-zip \
-    && apt-get install -y php7.1-soap \
-    && apt-get install -y php7.1-memcached \
-    && apt-get install -y php7.1-redis \
-    && apt-get install -y php7.1-bcmath \
-    && apt-get install -y php7.1-imap \
-    && apt-get install -y php7.1-ssh2 \
-    && apt-get install -y php7.1-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.1-geoip \
-    && apt-get install -y php7.1-amqp \
-    && apt-get install -y php7.1-mongo \
+                            php7.1-apc \
+                            php7.1-apcu \
+                            php7.1-curl \
+                            php7.1-cli \
+                            php7.1-gd \
+                            php7.1-json \
+                            php7.1-ldap \
+                            php7.1-mysql \
+                            php7.1-pgsql \
+                            php7.1-gettext \
+                            php7.1-intl \
+                            php7.1-xml \
+                            php7.1-mysql \
+                            php7.1-mbstring \
+                            php7.1-zip \
+                            php7.1-soap \
+                            php7.1-memcached \
+                            php7.1-redis \
+                            php7.1-bcmath \
+                            php7.1-imap \
+                            php7.1-ssh2 \
+                            php7.1-pcov \
+                            dh-php \
+                            php7.1-geoip \
+                            php7.1-amqp \
+                            php7.1-mongo \
 

--- a/template/components/php/7.2/install.sh.twig
+++ b/template/components/php/7.2/install.sh.twig
@@ -1,29 +1,28 @@
-
     && apt-get install -y php7.2-fpm \
-    && apt-get install -y php7.2-apc \
-    && apt-get install -y php7.2-apcu \
-    && apt-get install -y php7.2-curl \
-    && apt-get install -y php7.2-cli \
-    && apt-get install -y php7.2-gd \
-    && apt-get install -y php7.2-json \
-    && apt-get install -y php7.2-ldap \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-pgsql \
-    && apt-get install -y php7.2-gettext \
-    && apt-get install -y php7.2-intl \
-    && apt-get install -y php7.2-xml \
-    && apt-get install -y php7.2-mysql \
-    && apt-get install -y php7.2-mbstring \
-    && apt-get install -y php7.2-zip \
-    && apt-get install -y php7.2-soap \
-    && apt-get install -y php7.2-memcached \
-    && apt-get install -y php7.2-redis \
-    && apt-get install -y php7.2-bcmath \
-    && apt-get install -y php7.2-imap \
-    && apt-get install -y php7.2-ssh2 \
-    && apt-get install -y php7.2-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.2-geoip \
-    && apt-get install -y php7.2-amqp \
-    && apt-get install -y php7.2-mongo \
+                            php7.2-apc \
+                            php7.2-apcu \
+                            php7.2-curl \
+                            php7.2-cli \
+                            php7.2-gd \
+                            php7.2-json \
+                            php7.2-ldap \
+                            php7.2-mysql \
+                            php7.2-pgsql \
+                            php7.2-gettext \
+                            php7.2-intl \
+                            php7.2-xml \
+                            php7.2-mysql \
+                            php7.2-mbstring \
+                            php7.2-zip \
+                            php7.2-soap \
+                            php7.2-memcached \
+                            php7.2-redis \
+                            php7.2-bcmath \
+                            php7.2-imap \
+                            php7.2-ssh2 \
+                            php7.2-pcov \
+                            dh-php \
+                            php7.2-geoip \
+                            php7.2-amqp \
+                            php7.2-mongo \
 

--- a/template/components/php/7.3/install.sh.twig
+++ b/template/components/php/7.3/install.sh.twig
@@ -1,29 +1,28 @@
-
     && apt-get install -y php7.3-fpm \
-    && apt-get install -y php7.3-apc \
-    && apt-get install -y php7.3-apcu \
-    && apt-get install -y php7.3-curl \
-    && apt-get install -y php7.3-cli \
-    && apt-get install -y php7.3-gd \
-    && apt-get install -y php7.3-json \
-    && apt-get install -y php7.3-ldap \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-pgsql \
-    && apt-get install -y php7.3-gettext \
-    && apt-get install -y php7.3-intl \
-    && apt-get install -y php7.3-xml \
-    && apt-get install -y php7.3-mysql \
-    && apt-get install -y php7.3-mbstring \
-    && apt-get install -y php7.3-zip \
-    && apt-get install -y php7.3-soap \
-    && apt-get install -y php7.3-memcached \
-    && apt-get install -y php7.3-redis \
-    && apt-get install -y php7.3-bcmath \
-    && apt-get install -y php7.3-imap \
-    && apt-get install -y php7.3-ssh2 \
-    && apt-get install -y php7.3-pcov \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.3-geoip \
-    && apt-get install -y php7.3-amqp \
-    && apt-get install -y php7.3-mongo \
+                            php7.3-apc \
+                            php7.3-apcu \
+                            php7.3-curl \
+                            php7.3-cli \
+                            php7.3-gd \
+                            php7.3-json \
+                            php7.3-ldap \
+                            php7.3-mysql \
+                            php7.3-pgsql \
+                            php7.3-gettext \
+                            php7.3-intl \
+                            php7.3-xml \
+                            php7.3-mysql \
+                            php7.3-mbstring \
+                            php7.3-zip \
+                            php7.3-soap \
+                            php7.3-memcached \
+                            php7.3-redis \
+                            php7.3-bcmath \
+                            php7.3-imap \
+                            php7.3-ssh2 \
+                            php7.3-pcov \
+                            dh-php \
+                            php7.3-geoip \
+                            php7.3-amqp \
+                            php7.3-mongo \
 

--- a/template/components/php/7.4/install.sh.twig
+++ b/template/components/php/7.4/install.sh.twig
@@ -1,30 +1,30 @@
     && apt-get install -y php7.4-fpm \
-    && apt-get install -y php7.4-gd \
+                            php7.4-gd \
     #make sure mbstring is installed BEFORE iconv see: https://github.com/dockware/dockware/issues/36 => https://github.com/docker-library/php/issues/240#issuecomment-355489551
-    && apt-get install -y php7.4-mbstring \
-    && apt-get install -y php7.4-iconv \
-    && apt-get install -y php7.4-intl \
-    && apt-get install -y php7.4-json \
-    && apt-get install -y php7.4-xml \
-    && apt-get install -y php7.4-pdo \
-    && apt-get install -y php7.4-mysql \
-    && apt-get install -y php7.4-apcu \
-    && apt-get install -y php7.4-apc \
-    && apt-get install -y php7.4-curl \
-    && apt-get install -y php7.4-cli \
-    && apt-get install -y php7.4-ldap \
-    && apt-get install -y php7.4-pgsql \
-    && apt-get install -y php7.4-gettext \
-    && apt-get install -y php7.4-zip \
-    && apt-get install -y php7.4-soap \
-    && apt-get install -y php7.4-bcmath \
-    && apt-get install -y php7.4-redis \
-    && apt-get install -y php7.4-imap \
-    && apt-get install -y php7.4-ssh2 \
-    && apt-get install -y php7.4-pcov \
-    && apt-get install -y php7.4-mongo \
-    && apt-get install -y dh-php \
-    && apt-get install -y php7.4-geoip \
-    && apt-get install -y php7.4-amqp \
+                            php7.4-mbstring \
+                            php7.4-iconv \
+                            php7.4-intl \
+                            php7.4-json \
+                            php7.4-xml \
+                            php7.4-pdo \
+                            php7.4-mysql \
+                            php7.4-apcu \
+                            php7.4-apc \
+                            php7.4-curl \
+                            php7.4-cli \
+                            php7.4-ldap \
+                            php7.4-pgsql \
+                            php7.4-gettext \
+                            php7.4-zip \
+                            php7.4-soap \
+                            php7.4-bcmath \
+                            php7.4-redis \
+                            php7.4-imap \
+                            php7.4-ssh2 \
+                            php7.4-pcov \
+                            php7.4-mongo \
+                            dh-php \
+                            php7.4-geoip \
+                            php7.4-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \

--- a/template/components/php/8.0/install.sh.twig
+++ b/template/components/php/8.0/install.sh.twig
@@ -1,29 +1,29 @@
     && apt-get install -y php8.0-fpm \
-    && apt-get install -y php8.0-gd \
-    && apt-get install -y php8.0-iconv \
-    && apt-get install -y php8.0-intl \
+                            php8.0-gd \
+                            php8.0-iconv \
+                            php8.0-intl \
     #&& apt-get install -y php8.0-json \
-    && apt-get install -y php8.0-xml \
-    && apt-get install -y php8.0-mbstring \
-    && apt-get install -y php8.0-pdo \
-    && apt-get install -y php8.0-mysql \
-    && apt-get install -y php8.0-apc \
-    && apt-get install -y php8.0-apcu \
-    && apt-get install -y php8.0-curl \
-    && apt-get install -y php8.0-cli \
-    && apt-get install -y php8.0-ldap \
-    && apt-get install -y php8.0-pgsql \
-    && apt-get install -y php8.0-gettext \
-    && apt-get install -y php8.0-zip \
-    && apt-get install -y php8.0-soap \
-    && apt-get install -y php8.0-bcmath \
-    && apt-get install -y php8.0-redis \
-    && apt-get install -y php8.0-imap \
-    && apt-get install -y php8.0-ssh2 \
-    && apt-get install -y php8.0-pcov \
-    && apt-get install -y php8.0-mongo \
-    && apt-get install -y dh-php \
-#    && apt-get install -y php8.0-geoip \ not available for 8.0
-    && apt-get install -y php8.0-amqp \
+                            php8.0-xml \
+                            php8.0-mbstring \
+                            php8.0-pdo \
+                            php8.0-mysql \
+                            php8.0-apc \
+                            php8.0-apcu \
+                            php8.0-curl \
+                            php8.0-cli \
+                            php8.0-ldap \
+                            php8.0-pgsql \
+                            php8.0-gettext \
+                            php8.0-zip \
+                            php8.0-soap \
+                            php8.0-bcmath \
+                            php8.0-redis \
+                            php8.0-imap \
+                            php8.0-ssh2 \
+                            php8.0-pcov \
+                            php8.0-mongo \
+                            dh-php \
+#                            php8.0-geoip \ not available for 8.0
+                            php8.0-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \

--- a/template/components/php/8.1/install.sh.twig
+++ b/template/components/php/8.1/install.sh.twig
@@ -1,29 +1,29 @@
     && apt-get install -y php8.1-fpm \
-    && apt-get install -y php8.1-gd \
-    && apt-get install -y php8.1-iconv \
-    && apt-get install -y php8.1-intl \
+                            php8.1-gd \
+                            php8.1-iconv \
+                            php8.1-intl \
     #&& apt-get install -y php8.1-json \
-    && apt-get install -y php8.1-xml \
-    && apt-get install -y php8.1-mbstring \
-    && apt-get install -y php8.1-pdo \
-    && apt-get install -y php8.1-mysql \
-    && apt-get install -y php8.1-apc \
-    && apt-get install -y php8.1-apcu \
-    && apt-get install -y php8.1-curl \
-    && apt-get install -y php8.1-cli \
-    && apt-get install -y php8.1-ldap \
-    && apt-get install -y php8.1-pgsql \
-    && apt-get install -y php8.1-gettext \
-    && apt-get install -y php8.1-zip \
-    && apt-get install -y php8.1-soap \
-    && apt-get install -y php8.1-bcmath \
-    && apt-get install -y php8.1-redis \
-    && apt-get install -y php8.1-imap \
-    && apt-get install -y php8.1-ssh2 \
-    && apt-get install -y php8.1-pcov \
-    && apt-get install -y php8.1-mongo \
-    && apt-get install -y dh-php \
+                            php8.1-xml \
+                            php8.1-mbstring \
+                            php8.1-pdo \
+                            php8.1-mysql \
+                            php8.1-apc \
+                            php8.1-apcu \
+                            php8.1-curl \
+                            php8.1-cli \
+                            php8.1-ldap \
+                            php8.1-pgsql \
+                            php8.1-gettext \
+                            php8.1-zip \
+                            php8.1-soap \
+                            php8.1-bcmath \
+                            php8.1-redis \
+                            php8.1-imap \
+                            php8.1-ssh2 \
+                            php8.1-pcov \
+                            php8.1-mongo \
+                            dh-php \
     #&& apt-get install -y php8.1-geoip \ not available for 8.1
-    && apt-get install -y php8.1-amqp \
+                            php8.1-amqp \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \

--- a/template/components/php/8.2/install.sh.twig
+++ b/template/components/php/8.2/install.sh.twig
@@ -1,25 +1,25 @@
     && apt-get install -y php8.2-fpm \
-    && apt-get install -y php8.2-gd \
-    && apt-get install -y php8.2-iconv \
-    && apt-get install -y php8.2-intl \
-    && apt-get install -y php8.2-xml \
-    && apt-get install -y php8.2-mbstring \
-    && apt-get install -y php8.2-pdo \
-    && apt-get install -y php8.2-mysql \
-    && apt-get install -y php8.2-curl \
-    && apt-get install -y php8.2-cli \
-    && apt-get install -y php8.2-ldap \
-    && apt-get install -y php8.2-pgsql \
-    && apt-get install -y php8.2-gettext \
-    && apt-get install -y php8.2-zip \
-    && apt-get install -y php8.2-soap \
-    && apt-get install -y php8.2-bcmath \
-    && apt-get install -y php8.2-imap \
-    && apt-get install -y php8.2-redis \
-    && apt-get install -y php8.2-amqp \
-    && apt-get install -y php8.2-apcu \
-    && apt-get install -y php8.2-pcov \
-    && apt-get install -y php8.2-mongo \
-    && apt-get install -y dh-php \
+                            php8.2-gd \
+                            php8.2-iconv \
+                            php8.2-intl \
+                            php8.2-xml \
+                            php8.2-mbstring \
+                            php8.2-pdo \
+                            php8.2-mysql \
+                            php8.2-curl \
+                            php8.2-cli \
+                            php8.2-ldap \
+                            php8.2-pgsql \
+                            php8.2-gettext \
+                            php8.2-zip \
+                            php8.2-soap \
+                            php8.2-bcmath \
+                            php8.2-imap \
+                            php8.2-redis \
+                            php8.2-amqp \
+                            php8.2-apcu \
+                            php8.2-pcov \
+                            php8.2-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \

--- a/template/components/php/8.3/install.sh.twig
+++ b/template/components/php/8.3/install.sh.twig
@@ -1,26 +1,26 @@
     && apt-get install -y php8.3-fpm \
-    && apt-get install -y php8.3-gd \
-    && apt-get install -y php8.3-iconv \
-    && apt-get install -y php8.3-intl \
-    && apt-get install -y php8.3-xml \
-    && apt-get install -y php8.3-mbstring \
-    && apt-get install -y php8.3-pdo \
-    && apt-get install -y php8.3-mysql \
-    && apt-get install -y php8.3-curl \
-    && apt-get install -y php8.3-cli \
-    && apt-get install -y php8.3-ldap \
-    && apt-get install -y php8.3-pgsql \
-    && apt-get install -y php8.3-gettext \
-    && apt-get install -y php8.3-zip \
-    && apt-get install -y php8.3-soap \
-    && apt-get install -y php8.3-bcmath \
-    && apt-get install -y php8.3-imap \
-    && apt-get install -y php8.3-xdebug \
-    && apt-get install -y php8.3-redis \
-    && apt-get install -y php8.3-amqp \
-    && apt-get install -y php8.3-apcu \
-    && apt-get install -y php8.3-pcov \
-    && apt-get install -y php8.3-mongo \
-    && apt-get install -y dh-php \
+                            php8.3-gd \
+                            php8.3-iconv \
+                            php8.3-intl \
+                            php8.3-xml \
+                            php8.3-mbstring \
+                            php8.3-pdo \
+                            php8.3-mysql \
+                            php8.3-curl \
+                            php8.3-cli \
+                            php8.3-ldap \
+                            php8.3-pgsql \
+                            php8.3-gettext \
+                            php8.3-zip \
+                            php8.3-soap \
+                            php8.3-bcmath \
+                            php8.3-imap \
+                            php8.3-xdebug \
+                            php8.3-redis \
+                            php8.3-amqp \
+                            php8.3-apcu \
+                            php8.3-pcov \
+                            php8.3-mongo \
+                            dh-php \
     # shopware required pcre
-    && apt-get install -y libpcre3 libpcre3-dev \
+                            libpcre3 libpcre3-dev \

--- a/template/components/shopware/shopware6/install_6.5.sh.twig
+++ b/template/components/shopware/shopware6/install_6.5.sh.twig
@@ -1,5 +1,3 @@
-{% extends "variants/dev/Dockerfile.base.sh.twig" %}
-
 {% block shopware %}
 COPY ./assets/shopware6/DockwareSamplePlugin /var/www/html/custom/plugins/DockwareSamplePlugin
 

--- a/template/components/shopware/shopware6/install_6.6.sh.twig
+++ b/template/components/shopware/shopware6/install_6.6.sh.twig
@@ -1,5 +1,3 @@
-{% extends "variants/dev/Dockerfile.base.sh.twig" %}
-
 {% block shopware %}
 COPY ./assets/shopware6/DockwareSamplePlugin /var/www/html/custom/plugins/DockwareSamplePlugin
 

--- a/template/components/xdebug/install.sh.twig
+++ b/template/components/xdebug/install.sh.twig
@@ -7,7 +7,6 @@
     && rm -rf {{xdebug_tag}}.zip \
     && mv xdebug-{{xdebug_tag}} xdebug \
     && cd /var/www/xdebug \
-    && sudo apt-get update \
     && sudo phpize{{ php_version }} \
     && sudo ./configure --with-php-config=/usr/bin/php-config{{php_version}} \
     && sudo make \

--- a/variants/flex/Dockerfile.base.sh.twig
+++ b/variants/flex/Dockerfile.base.sh.twig
@@ -21,6 +21,9 @@
 {% block components_pimpmylog %}
 {% endblock %}
 
+{% block components_pimpmylog_user_config %}
+{% endblock %}
+
 {% block assets_install_shopware6 %}
 {% endblock %}
 


### PR DESCRIPTION
please compare [this](https://app.circleci.com/pipelines/github/dockware/dockware/643/workflows/bd899014-b929-4342-9a0c-ecb86f2ce572/jobs/1319) with [this](https://github.com/The-OAsis-Hub/dockware/actions/runs/10514891574) build for reference.

summary:
- apt-get update only once
- group apt-get install's
- don't extend the variant base dockerfile in the shopware install templates to avoid duplicates
- other small changes to avoid cache invalidation
