### PR TITLE
Fix tideways-daemon init script

### DIFF
--- a/template/assets/assets/tideways/tideways-daemon
+++ b/template/assets/assets/tideways/tideways-daemon
@@ -26,7 +26,7 @@ if [ -f "$DEFAULTFILE" ]; then
     . "$DEFAULTFILE"
 fi
 
-DAEMON_OPTS="--log=$TIDEWAYS_DAEMON_LOGFILE --pidfile=$PIDFILE"
+DAEMON_OPTS="--log=$TIDEWAYS_DAEMON_LOGFILE"
 
 export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"
 
@@ -49,7 +49,7 @@ case "$1" in
         echo -n "Starting daemon: "$NAME
         mkdir $PIDDIR -p
         chown tideways.tideways $PIDDIR -R
-        start-stop-daemon -S --background --pidfile $PIDFILE -c tideways --user tideways --startas /bin/bash -- -c "exec $DAEMON $DAEMON_OPTS $TIDEWAYS_DAEMON_EXTRA 2>> /var/log/tideways/daemon.log"
+        start-stop-daemon -S --background --pidfile $PIDFILE --make-pidfile -c tideways --user tideways --startas /bin/bash -- -c "exec $DAEMON $DAEMON_OPTS $TIDEWAYS_DAEMON_EXTRA 2>> /var/log/tideways/daemon.log"
         echo "."
     ;;
   stop)
@@ -62,7 +62,7 @@ case "$1" in
         mkdir $PIDDIR -p
         chown tideways.tideways $PIDDIR -R
         start-stop-daemon --stop --quiet --retry 30 --pidfile $PIDFILE
-        start-stop-daemon -S --background --pidfile $PIDFILE -c tideways --user tideways --startas /bin/bash -- -c "exec $DAEMON $DAEMON_OPTS $TIDEWAYS_DAEMON_EXTRA 2>> /var/log/tideways/daemon.log"
+        start-stop-daemon -S --background --pidfile $PIDFILE --make-pidfile -c tideways --user tideways --startas /bin/bash -- -c "exec $DAEMON $DAEMON_OPTS $TIDEWAYS_DAEMON_EXTRA 2>> /var/log/tideways/daemon.log"
         echo "."
     ;;
   status)


### PR DESCRIPTION
tideways-daemon 1.9.6 removed support for the --pidfile option [1], because tracking processes via their PID is inherently unreliable.

Migrate to start-stop-daemon’s `--make-pidfile` option as a short-term fix, until either adding a proper service manager to the image or using the official Tideways Daemon Docker Image [2].

[1] https://tideways.com/profiler/blog/changelog/daemon-1-9-6-released
[2] https://support.tideways.com/documentation/setup/installation/docker-with-compose.html#with-docker-compose