### PR TITLE
NTR: Add zstd for php >=8.0

### DIFF
--- a/template/components/php/8.0/install.sh.twig
+++ b/template/components/php/8.0/install.sh.twig
@@ -2,7 +2,6 @@
                             php8.0-gd \
                             php8.0-iconv \
                             php8.0-intl \
-    #&& apt-get install -y php8.0-json \
                             php8.0-xml \
                             php8.0-mbstring \
                             php8.0-pdo \
@@ -23,7 +22,7 @@
                             php8.0-pcov \
                             php8.0-mongo \
                             dh-php \
-#                            php8.0-geoip \ not available for 8.0
                             php8.0-amqp \
+                            php8.0-zstd \
     # shopware required pcre
                             libpcre3 libpcre3-dev \

--- a/template/components/php/8.1/install.sh.twig
+++ b/template/components/php/8.1/install.sh.twig
@@ -2,7 +2,6 @@
                             php8.1-gd \
                             php8.1-iconv \
                             php8.1-intl \
-    #&& apt-get install -y php8.1-json \
                             php8.1-xml \
                             php8.1-mbstring \
                             php8.1-pdo \
@@ -23,7 +22,7 @@
                             php8.1-pcov \
                             php8.1-mongo \
                             dh-php \
-    #&& apt-get install -y php8.1-geoip \ not available for 8.1
                             php8.1-amqp \
+                            php8.1-zstd \
     # shopware required pcre
                             libpcre3 libpcre3-dev \

--- a/template/components/php/8.2/install.sh.twig
+++ b/template/components/php/8.2/install.sh.twig
@@ -21,5 +21,6 @@
                             php8.2-pcov \
                             php8.2-mongo \
                             dh-php \
+                            php8.2-zstd \
     # shopware required pcre
                             libpcre3 libpcre3-dev \

--- a/template/components/php/8.3/install.sh.twig
+++ b/template/components/php/8.3/install.sh.twig
@@ -22,5 +22,6 @@
                             php8.3-pcov \
                             php8.3-mongo \
                             dh-php \
+                            php8.3-zstd \
     # shopware required pcre
                             libpcre3 libpcre3-dev \

--- a/template/components/php/8.4/install.sh.twig
+++ b/template/components/php/8.4/install.sh.twig
@@ -22,5 +22,6 @@
                             php8.4-pcov \
                             php8.4-mongo \
                             dh-php \
+                            php8.4-zstd \
     # shopware required pcre
                             libpcre3 libpcre3-dev \


### PR DESCRIPTION
Simple cleanup of commented out code

And add `zstd` to default installation.

Resolves #237 