### PR TITLE
Disable tideways: added check if file exists before renaming

### DIFF
--- a/template/entrypoint.global.sh.twig
+++ b/template/entrypoint.global.sh.twig
@@ -201,8 +201,12 @@ if [ $RECOVERY_MODE = 0 ]; then
         echo "-----------------------------------------------------------"
     else
         echo "DOCKWARE: Tideways not activated. Disabling..."
-        sudo mv /etc/php/$PHP_VERSION/fpm/conf.d/20-tideways.ini /etc/php/$PHP_VERSION/fpm/conf.d/20-tideways.disabled
-        sudo mv /etc/php/$PHP_VERSION/cli/conf.d/20-tideways.ini /etc/php/$PHP_VERSION/cli/conf.d/20-tideways.disabled
+        if [ -f /etc/php/$PHP_VERSION/fpm/conf.d/20-tideways.ini ]; then
+            sudo mv /etc/php/$PHP_VERSION/fpm/conf.d/20-tideways.ini /etc/php/$PHP_VERSION/fpm/conf.d/20-tideways.disabled
+        fi
+        if [ -f /etc/php/$PHP_VERSION/cli/conf.d/20-tideways.ini ]; then
+            sudo mv /etc/php/$PHP_VERSION/cli/conf.d/20-tideways.ini /etc/php/$PHP_VERSION/cli/conf.d/20-tideways.disabled
+        fi
     fi
     {% endblock %}
 


### PR DESCRIPTION
The newly introduced change to disable tideways if it's not configured has an issue: The renaming only works on the first start. If you restart the container the entrypoint script is executed, but the file is already renamed => crash.

Added checks if file exists before renaming it.